### PR TITLE
dirs: Fallback to cache dir if no runtime dir

### DIFF
--- a/src/dirs.rs
+++ b/src/dirs.rs
@@ -5,9 +5,10 @@ pub fn make_all() -> Result<()> {
     std::fs::create_dir_all(&cache_dir)
         .context(crate::error::CreateDirectory { file: cache_dir })?;
 
-    let runtime_dir = runtime_dir();
-    std::fs::create_dir_all(&runtime_dir)
-        .context(crate::error::CreateDirectory { file: runtime_dir })?;
+    if let Some(runtime_dir) = runtime_dir() {
+        std::fs::create_dir_all(&runtime_dir)
+            .context(crate::error::CreateDirectory { file: runtime_dir })?;
+    }
 
     let data_dir = data_dir();
     std::fs::create_dir_all(&data_dir)
@@ -30,7 +31,10 @@ pub fn db_file(server: &str, email: &str) -> std::path::PathBuf {
 }
 
 pub fn pid_file() -> std::path::PathBuf {
-    runtime_dir().join("pidfile")
+    match runtime_dir() {
+        Some(d) => d.join("pidfile"),
+        None => cache_dir().join("pidfile"),
+    }
 }
 
 pub fn agent_stdout_file() -> std::path::PathBuf {
@@ -42,7 +46,10 @@ pub fn agent_stderr_file() -> std::path::PathBuf {
 }
 
 pub fn socket_file() -> std::path::PathBuf {
-    runtime_dir().join("socket")
+    match runtime_dir() {
+        Some(d) => d.join("socket"),
+        None => cache_dir().join("socket"),
+    }
 }
 
 fn config_dir() -> std::path::PathBuf {
@@ -60,7 +67,10 @@ fn data_dir() -> std::path::PathBuf {
     project_dirs.data_dir().to_path_buf()
 }
 
-fn runtime_dir() -> std::path::PathBuf {
+fn runtime_dir() -> Option<std::path::PathBuf> {
     let project_dirs = directories::ProjectDirs::from("", "", "rbw").unwrap();
-    project_dirs.runtime_dir().unwrap().to_path_buf()
+    match project_dirs.runtime_dir() {
+        Some(d) => Some(d.to_path_buf()),
+        None => None,
+    }
 }


### PR DESCRIPTION
The `XDG_RUNTIME_DIR` environment variable is not always set.  It is
mostly used by Linux distributions that use systemd; others may or may
not use it.

There is no general consensus on the appropriate location for sockets,
pipes, PID files, etc. in the absence of a specified runtime directory.
Historically, applications would create a "dot directory" (e.g.
`~/.gnupg`) and store all of their files there.  Some applications,
including *libvirt* and *gnome-keyring*, use the cache directory, while
others (e.g. many Electron-based applications) store everything in the
configuration directory.  Finally, there is the age-old tradition of
putting everything in `/tmp`.

This commit adds fallback logic anywhere the runtime directory is used.
If the runtime directory is not configured, the cache directory is used
in its place.

Fixes #3