### PR TITLE
Add CipherString type 6 support

### DIFF
--- a/src/cipherstring.rs
+++ b/src/cipherstring.rs
@@ -67,6 +67,9 @@ impl CipherString {
                 })
             }
             4 | 6 => {
+                // the only difference between 4 and 6 is the HMAC256 signature appended at the end
+                // https://github.com/bitwarden/jslib/blob/785b681f61f81690de6df55159ab07ae710bcfad/src/enums/encryptionType.ts#L8
+                // format is: <cipher_text_b64>|<hmac_sig>
                 let contents = contents.split("|").next().unwrap();
                 let ciphertext = base64::decode(contents)
                     .context(crate::error::InvalidBase64)?;

--- a/src/cipherstring.rs
+++ b/src/cipherstring.rs
@@ -66,7 +66,8 @@ impl CipherString {
                     mac,
                 })
             }
-            4 => {
+            4 | 6 => {
+                let contents = contents.split("|").next().unwrap();
                 let ciphertext = base64::decode(contents)
                     .context(crate::error::InvalidBase64)?;
                 Ok(Self::Asymmetric { ciphertext })


### PR DESCRIPTION
Fixes #5.

Cipherstring type `6` is `Rsa2048_OaepSha1_HmacSha256_B64`.
`rbw` currently supports `Rsa2048_OaepSha1_B64` but not the deprecated option above.

The `HMAC` `SHA256` deprecated versions append a `|` and the signature to the ciphertext. This fix simply ignores the appended signature, since it's a [deprecated mode anyways](https://github.com/bitwarden/jslib/blob/c62f5287cd259c6385c6e79193e0e5e1746c7a3c/src/services/crypto.service.ts#L620).

This PR does not add support for [`Rsa2048_OaepSha256_HmacSha256_B64`](https://github.com/bitwarden/jslib/blob/785b681f61f81690de6df55159ab07ae710bcfad/src/enums/encryptionType.ts#L7) since I have no way of testing it, although I'd imagine its the same.