### PR TITLE
Zero-pad auth code

### DIFF
--- a/src/bin/rbw/commands.rs
+++ b/src/bin/rbw/commands.rs
@@ -1435,7 +1435,7 @@ fn remove_db() -> anyhow::Result<()> {
 
 fn generate_totp(secret: &str) -> anyhow::Result<String> {
     Ok(format!(
-        "{}",
+        "{:06}",
         oath::totp_raw_now(
             &base32::decode(
                 base32::Alphabet::RFC4648 { padding: false },


### PR DESCRIPTION
`oath::totp_raw_now` doesn't zero-pad the result.

For example the following code outputs `3406` instead of `003406`:

```rust
extern crate oath;

use oath::{totp_raw_custom_time, HashType};

fn main () {
    let res = totp_raw_custom_time(b"12345678901234567890", 6, 0, 30, 26*365*24*60*60, &HashType::SHA1);
    println!("{}", res);
}
```