### PR TITLE
Improvements to fzf script

### DIFF
--- a/bin/rbw-fzf
+++ b/bin/rbw-fzf
@@ -2,4 +2,4 @@
 set -eu
 set -o pipefail
 
-rbw ls --fields name,user,folder | perl -plE'/^([^\t]*)\t([^\t]*)\t([^\t]*)$/; $_ = join("/", grep { length } ($3, $1, $2)) . "\t$_"' | sort | fzf --with-nth=1 | perl -ple'/^([^\t]*)\t([^\t]*)\t([^\t]*)\t([^\t]*)$/; $_ = "$2 $3"' | xargs -r rbw get
+rbw ls --fields name,user,folder | fzf | sed -E 's/([^\t]+)$/--folder=\1/' | xargs -d'\t' rbw get


### PR DESCRIPTION
This is a vault that the existing command would have a hard time with:

```shell
% rbw ls --fields name,user,folder
host1.com       user1
host1.com       user1   folder1
host2.com       user2   spaces in folder2
```

First problem is, `user1` has two duplicate entries, one in a dir and one without a dir (edge case, I know):

```shell
% rbw get --folder=folder1 host1.com user1
user1pass-with-folder
% rbw get host1.com user1 
user1pass-no-folder
```

Since the folder is removed, I get the wrong entry when I choose the one in `folder1`:

```shell
% rbw-fzf
# Choose "folder1/host1.com/user1" in fzf
user1pass-no-folder
```


Second problem is, `user2`'s login is in a folder with spaces in the name:

```shell
% rbw get --folder='spaces in folder2' host2.com user2
user2pass
```

When I run the existing `fzf` script, I get this:

```shell
  spaces
  host1.com/user1
> folder1/host1.com/user1
  3/3
> _
```

When I should get this:

```shell
  spaces in folder2/host2.com/user2
  host1.com/user1
> folder1/host1.com/user1
  3/3
> _
```

The new version I'm proposing solves both problems. It's a bit shorter as well.

One thing to note is, the fzf search results list format is a bit different than the original:

```shell
  host2.com       user2   spaces in folder2
  host1.com       user1   folder1
> host1.com       user1
  3/3
> _
```

I don't mind it, but you might. If you like the directory first like you had it before, you can rearrange the fzf entries by passing `--with-nth=3,1,2 -d'\t'` to `fzf`, then fiddle with the sed command.