### PR TITLE
Support for Bitwarden API key authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ configuration options:
 
 * `email`: The email address to use as the account name when logging into the
   Bitwarden server. Required.
+* `client_id`: Client ID of your personal API key, used to bypass captcha.
+  Required.
+* `client_secret`: Client secret of your personal API key, used to bypass
+  captcha. Required.
 * `base_url`: The URL of the Bitwarden server to use. Defaults to the official
   server at `https://api.bitwarden.com/` if unset.
 * `identity_url`: The URL of the Bitwarden identity server to use. If unset,

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,6 +6,8 @@ use tokio::io::AsyncReadExt as _;
 #[derive(serde::Serialize, serde::Deserialize, Debug)]
 pub struct Config {
     pub email: Option<String>,
+    pub client_id : Option<String>,
+    pub client_secret : Option<String>,
     pub base_url: Option<String>,
     pub identity_url: Option<String>,
     #[serde(default = "default_lock_timeout")]
@@ -18,6 +20,8 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             email: Default::default(),
+            client_id: Default::default(),
+            client_secret: Default::default(),
             base_url: Default::default(),
             identity_url: Default::default(),
             lock_timeout: default_lock_timeout(),

--- a/src/db.rs
+++ b/src/db.rs
@@ -162,7 +162,6 @@ pub struct HistoryEntry {
 #[derive(serde::Serialize, serde::Deserialize, Default, Debug)]
 pub struct Db {
     pub access_token: Option<String>,
-    pub refresh_token: Option<String>,
 
     pub iterations: Option<u32>,
     pub protected_key: Option<String>,
@@ -289,7 +288,6 @@ impl Db {
 
     pub fn needs_login(&self) -> bool {
         self.access_token.is_none()
-            || self.refresh_token.is_none()
             || self.iterations.is_none()
             || self.protected_key.is_none()
     }


### PR DESCRIPTION
Bitwarden servers now require captcha responses for all non-
API clients. Require the use of the API key to bypass this
restriction.

Remove call to /accounts/prelogin as KDF information is
returned in the API key login flow.

API scoped authentication does not provide a refresh token and so
requires a call to /connect/token/ with the API key id & secret
when the access token expires

It may be possible to retrieve the user email via some
API call but that capability is unclear as of now.

I'm not sure that this is the best route to take since it is
opinionated on requiring the API key, which may not be required.

New to rust, so any pointers/tips welcome.