### PR TITLE
support for client certificates

### DIFF
--- a/src/actions.rs
+++ b/src/actions.rs
@@ -1,12 +1,17 @@
 use crate::prelude::*;
 
+fn api_client() -> Result<(crate::api::Client, crate::config::Config)> {
+    let config = crate::config::Config::load()?;
+    let client =
+        crate::api::Client::new(&config.base_url(), &config.identity_url(), &config.client_cert_path());
+    Ok((client, config))
+}
+
 pub async fn register(
     email: &str,
     apikey: crate::locked::ApiKey,
 ) -> Result<()> {
-    let config = crate::config::Config::load_async().await?;
-    let client =
-        crate::api::Client::new(&config.base_url(), &config.identity_url());
+    let (client, config) = api_client()?;
 
     client
         .register(email, &crate::config::device_id(&config).await?, &apikey)
@@ -21,10 +26,7 @@ pub async fn login(
     two_factor_token: Option<&str>,
     two_factor_provider: Option<crate::api::TwoFactorProviderType>,
 ) -> Result<(String, String, u32, String)> {
-    let config = crate::config::Config::load_async().await?;
-    let client =
-        crate::api::Client::new(&config.base_url(), &config.identity_url());
-
+    let (client, config) = api_client()?;
     let iterations = client.prelogin(email).await?;
     let identity =
         crate::identity::Identity::new(email, &password, iterations)?;
@@ -121,9 +123,7 @@ async fn sync_once(
     std::collections::HashMap<String, String>,
     Vec<crate::db::Entry>,
 )> {
-    let config = crate::config::Config::load_async().await?;
-    let client =
-        crate::api::Client::new(&config.base_url(), &config.identity_url());
+    let (client, _) = api_client()?;
     client.sync(access_token).await
 }
 
@@ -147,9 +147,7 @@ fn add_once(
     notes: Option<&str>,
     folder_id: Option<&str>,
 ) -> Result<()> {
-    let config = crate::config::Config::load()?;
-    let client =
-        crate::api::Client::new(&config.base_url(), &config.identity_url());
+    let (client, _) = api_client()?;
     client.add(access_token, name, data, notes, folder_id)?;
     Ok(())
 }
@@ -189,9 +187,7 @@ fn edit_once(
     folder_uuid: Option<&str>,
     history: &[crate::db::HistoryEntry],
 ) -> Result<()> {
-    let config = crate::config::Config::load()?;
-    let client =
-        crate::api::Client::new(&config.base_url(), &config.identity_url());
+    let (client, _) = api_client()?;
     client.edit(
         access_token,
         id,
@@ -216,9 +212,7 @@ pub fn remove(
 }
 
 fn remove_once(access_token: &str, id: &str) -> Result<()> {
-    let config = crate::config::Config::load()?;
-    let client =
-        crate::api::Client::new(&config.base_url(), &config.identity_url());
+    let (client, _) = api_client()?;
     client.remove(access_token, id)?;
     Ok(())
 }
@@ -233,9 +227,7 @@ pub fn list_folders(
 }
 
 fn list_folders_once(access_token: &str) -> Result<Vec<(String, String)>> {
-    let config = crate::config::Config::load()?;
-    let client =
-        crate::api::Client::new(&config.base_url(), &config.identity_url());
+    let (client, _) = api_client()?;
     client.folders(access_token)
 }
 
@@ -250,9 +242,7 @@ pub fn create_folder(
 }
 
 fn create_folder_once(access_token: &str, name: &str) -> Result<String> {
-    let config = crate::config::Config::load()?;
-    let client =
-        crate::api::Client::new(&config.base_url(), &config.identity_url());
+    let (client, _) = api_client()?;
     client.create_folder(access_token, name)
 }
 
@@ -302,15 +292,11 @@ where
 }
 
 fn exchange_refresh_token(refresh_token: &str) -> Result<String> {
-    let config = crate::config::Config::load()?;
-    let client =
-        crate::api::Client::new(&config.base_url(), &config.identity_url());
+    let (client, _) = api_client()?;
     client.exchange_refresh_token(refresh_token)
 }
 
 async fn exchange_refresh_token_async(refresh_token: &str) -> Result<String> {
-    let config = crate::config::Config::load_async().await?;
-    let client =
-        crate::api::Client::new(&config.base_url(), &config.identity_url());
+    let (client, _) = api_client()?;
     client.exchange_refresh_token_async(refresh_token).await
 }

--- a/src/bin/rbw/commands.rs
+++ b/src/bin/rbw/commands.rs
@@ -405,6 +405,7 @@ pub fn config_set(key: &str, value: &str) -> anyhow::Result<()> {
         "email" => config.email = Some(value.to_string()),
         "base_url" => config.base_url = Some(value.to_string()),
         "identity_url" => config.identity_url = Some(value.to_string()),
+        "client_cert_path" => config.client_cert_path = Some(value.to_string()),
         "lock_timeout" => {
             let timeout = value
                 .parse()
@@ -437,6 +438,7 @@ pub fn config_unset(key: &str) -> anyhow::Result<()> {
         "email" => config.email = None,
         "base_url" => config.base_url = None,
         "identity_url" => config.identity_url = None,
+        "client_cert_path" => config.client_cert_path = None,
         "lock_timeout" => {
             config.lock_timeout = rbw::config::default_lock_timeout();
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,7 @@ pub struct Config {
     pub lock_timeout: u64,
     #[serde(default = "default_pinentry")]
     pub pinentry: String,
+    pub client_cert_path: Option<String>,
     // backcompat, no longer generated in new configs
     #[serde(skip_serializing)]
     pub device_id: Option<String>,
@@ -25,6 +26,7 @@ impl Default for Config {
             identity_url: None,
             lock_timeout: default_lock_timeout(),
             pinentry: default_pinentry(),
+            client_cert_path: None,
             device_id: None,
         }
     }
@@ -146,6 +148,12 @@ impl Config {
                 |url| format!("{}/identity", url.trim_end_matches('/')),
             )
         })
+    }
+
+    #[must_use]
+    pub fn client_cert_path(&self) -> String {
+        self.client_cert_path.clone()
+            .unwrap_or_else(|| "".to_string())
     }
 
     #[must_use]


### PR DESCRIPTION
Added config `client_cert_path` to be used such as:

```
rbw config set client_cert_path /path/to/pem
```

File should contain certificate and private key (`cat private.key client.pem > final.path`)

While bitwarden server (or vaultwarden) do not support mTLS, self-hosting users can have cloudflare/nginx/traefik/whatever in front requiring one.

Even if not widely used, I believe it's a very small change, easy enough to support.