### PR TITLE
Support multiple profiles with an environment variable

### DIFF
--- a/src/bin/rbw-agent/actions.rs
+++ b/src/bin/rbw-agent/actions.rs
@@ -367,7 +367,7 @@ pub async fn unlock(
             let password = rbw::pinentry::getpin(
                 &config_pinentry().await?,
                 "Master Password",
-                "Unlock the local database",
+                &format!("Unlock the local database for '{}'", rbw::dirs::profile()),
                 err.as_deref(),
                 tty,
                 true,

--- a/src/dirs.rs
+++ b/src/dirs.rs
@@ -79,32 +79,45 @@ pub fn socket_file() -> std::path::PathBuf {
 
 #[must_use]
 fn config_dir() -> std::path::PathBuf {
-    let project_dirs = directories::ProjectDirs::from("", "", "rbw").unwrap();
+    let project_dirs =
+        directories::ProjectDirs::from("", "", &profile()).unwrap();
     project_dirs.config_dir().to_path_buf()
 }
 
 #[must_use]
 fn cache_dir() -> std::path::PathBuf {
-    let project_dirs = directories::ProjectDirs::from("", "", "rbw").unwrap();
+    let project_dirs =
+        directories::ProjectDirs::from("", "", &profile()).unwrap();
     project_dirs.cache_dir().to_path_buf()
 }
 
 #[must_use]
 fn data_dir() -> std::path::PathBuf {
-    let project_dirs = directories::ProjectDirs::from("", "", "rbw").unwrap();
+    let project_dirs =
+        directories::ProjectDirs::from("", "", &profile()).unwrap();
     project_dirs.data_dir().to_path_buf()
 }
 
 #[must_use]
 fn runtime_dir() -> std::path::PathBuf {
-    let project_dirs = directories::ProjectDirs::from("", "", "rbw").unwrap();
+    let project_dirs =
+        directories::ProjectDirs::from("", "", &profile()).unwrap();
     match project_dirs.runtime_dir() {
         Some(dir) => dir.to_path_buf(),
         None => format!(
-            "{}/rbw-{}",
+            "{}/{}-{}",
             std::env::temp_dir().to_string_lossy(),
+            &profile(),
             nix::unistd::getuid().as_raw()
         )
         .into(),
+    }
+}
+
+#[must_use]
+pub fn profile() -> String {
+    match std::env::var("RBW_PROFILE") {
+        Ok(profile) if !profile.is_empty() => format!("rbw-{}", profile),
+        _ => "rbw".to_string(),
     }
 }


### PR DESCRIPTION
This introduces the `RBW_PROFILE` environment variable to be able to run multiple instances in parallel, that will use different configuration paths.
To use this feature, simply run `rbw` with the environment variable set to any string that is valid for a path. Setting it to an empty string is like not setting it at all.
e.g.:
* `RBW_PROFILE=perso rbw list`
* `RBW_PROFILE=pro rbw list`

Fixes #48 and probably #28.