### PR TITLE
Added a field flag to the get command

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ out by running `rbw purge`, and you can explicitly lock the database by running
 functionality.
 
 Run `rbw get <name>` to get your passwords. If you also want to get the username
-or the note associated, you can use the flag `--full`. 
+or the note associated, you can use the flag `--full`. You can also use the flag
+`--field={field}` to get whatever default or custom field you want.
 
 *Note to users of the official Bitwarden server (at bitwarden.com)*: The
 official server has a tendency to detect command line traffic as bot traffic

--- a/src/bin/rbw/main.rs
+++ b/src/bin/rbw/main.rs
@@ -75,6 +75,8 @@ enum Opt {
         user: Option<String>,
         #[structopt(long, help = "Folder name to search in")]
         folder: Option<String>,
+        #[structopt(short, long, help = "Field to get")]
+        field: Option<String>,
         #[structopt(
             long,
             help = "Display the notes in addition to the password"
@@ -317,8 +319,15 @@ fn main(opt: Opt) {
             name,
             user,
             folder,
+            field,
             full,
-        } => commands::get(name, user.as_deref(), folder.as_deref(), *full),
+        } => commands::get(
+            name,
+            user.as_deref(),
+            folder.as_deref(),
+            field.as_deref(),
+            *full,
+        ),
         Opt::Code { name, user, folder } => {
             commands::code(name, user.as_deref(), folder.as_deref())
         }


### PR DESCRIPTION
I added a basic `--field` flag that can be used to get any specific field from an item when using the `get` command. The idea is to make it easier for someone to access just the username or whatever custom field they've defined in an item without needing to use the `--full` flag and then parsing the output