### PR TITLE
add support for raw json output

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ functionality.
 
 Run `rbw get <name>` to get your passwords. If you also want to get the username
 or the note associated, you can use the flag `--full`. You can also use the flag
-`--field={field}` to get whatever default or custom field you want.
+`--field={field}` to get whatever default or custom field you want. The `--raw`
+flag will show the output as JSON.
 
 *Note to users of the official Bitwarden server (at bitwarden.com)*: The
 official server has a tendency to detect command line traffic as bot traffic

--- a/src/bin/rbw/main.rs
+++ b/src/bin/rbw/main.rs
@@ -81,6 +81,8 @@ enum Opt {
         field: Option<String>,
         #[arg(long, help = "Display the notes in addition to the password")]
         full: bool,
+        #[structopt(long, help = "Display output as JSON")]
+        raw: bool,
     },
 
     #[command(about = "Display the authenticator code for a given entry")]
@@ -319,12 +321,14 @@ fn main() {
             folder,
             field,
             full,
+            raw,
         } => commands::get(
             name,
             user.as_deref(),
             folder.as_deref(),
             field.as_deref(),
             *full,
+            *raw,
         ),
         Opt::Code { name, user, folder } => {
             commands::code(name, user.as_deref(), folder.as_deref())


### PR DESCRIPTION
This is a very basic implementation, and I wanted to get some feedback on the direction before taking it further. What do you think so far? My goal is compatibility with chezmoi's [bitwarden](https://www.chezmoi.io/reference/templates/bitwarden-functions/bitwarden/) and [bitwardenFields](https://www.chezmoi.io/reference/templates/bitwarden-functions/bitwardenFields/) functions, which uses the official cli's json output, but general usability is also good.

fixes #36

example usage:

```json
$ cargo run -q --bin rbw -- get --raw test-entry
{
  "id": "adf723e1-ab03-4ff3-81aa-f5f3c2b68a5f",
  "folder": null,
  "name": "test-entry",
  "data": {
    "username": "foo",
    "password": "hunter2",
    "totp": null,
    "uris": [
      {
        "uri": "example.com",
        "match_type": null
      }
    ]
  },
  "fields": [
    {
      "name": "some-text",
      "value": "idk"
    },
    {
      "name": "something-hidden",
      "value": "a secret"
    },
    {
      "name": "bool-thing",
      "value": "true"
    },
    {
      "name": "idk",
      "value": null
    }
  ],
  "notes": "blah",
  "history": []
}
```

