### PR TITLE
Add bw-ssh related project

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,3 +95,4 @@ the instructions [here](https://bitwarden.com/help/article/personal-api-key/).
 ## Related projects
 
 * [rofi-rbw](https://github.com/fdw/rofi-rbw): A rofi frontend for Bitwarden
+* [bw-ssh](https://framagit.org/Glandos/bw-ssh/): Manage SSH key passphrases in Bitwarden


### PR DESCRIPTION
This is clearly a self-made ad for my project here. Feel free to dismiss.

I was previously using some `env SSHPASS=(rbw get "smtp-out1.example.com" "root") sshpass -e ssh root@smtp-out1.example.com` and thought that it was not optimal. I've found some projects that store the entire private key in Bitwarden, which is defeating the purpose of *private* key.

So, I created this. This is really a custom tool, made for me, as a proof-of-concept. If people like it, I'll make it more user-friendly.