### PR TITLE
add yubikey support

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -62,6 +62,7 @@ impl TwoFactorProviderType {
     pub fn message(&self) -> &str {
         match *self {
             Self::Authenticator => "Enter the 6 digit verification code from your authenticator app.",
+            Self::Yubikey => "Insert your Yubikey and push the button.",
             Self::Email => "Enter the PIN you received via email.",
             _ => "Enter the code."
         }
@@ -71,6 +72,7 @@ impl TwoFactorProviderType {
     pub fn header(&self) -> &str {
         match *self {
             Self::Authenticator => "Authenticator App",
+            Self::Yubikey => "Yubikey",
             Self::Email => "Email Code",
             _ => "Two Factor Authentication",
         }

--- a/src/bin/rbw-agent/actions.rs
+++ b/src/bin/rbw-agent/actions.rs
@@ -148,6 +148,7 @@ pub async fn login(
                 Err(rbw::error::Error::TwoFactorRequired { providers }) => {
                     let supported_types = vec![
                         rbw::api::TwoFactorProviderType::Authenticator,
+                        rbw::api::TwoFactorProviderType::Yubikey,
                         rbw::api::TwoFactorProviderType::Email,
                     ];
 


### PR DESCRIPTION
This is all that's needed to support Yubikey hardware tokens in OTP mode (https://developers.yubico.com/OTP/)

Fixes: #7 