### PR TITLE
Add support for copying (T)OTP code to clipboard

### DIFF
--- a/src/bin/rbw/commands.rs
+++ b/src/bin/rbw/commands.rs
@@ -886,7 +886,7 @@ pub fn get(
     Ok(())
 }
 
-pub fn code(
+pub fn otp(
     name: &str,
     user: Option<&str>,
     folder: Option<&str>,

--- a/src/bin/rbw/commands.rs
+++ b/src/bin/rbw/commands.rs
@@ -890,6 +890,7 @@ pub fn code(
     name: &str,
     user: Option<&str>,
     folder: Option<&str>,
+    clipboard: bool,
 ) -> anyhow::Result<()> {
     unlock()?;
 
@@ -906,7 +907,14 @@ pub fn code(
 
     if let DecryptedData::Login { totp, .. } = decrypted.data {
         if let Some(totp) = totp {
-            println!("{}", generate_totp(&totp)?);
+            let totp = generate_totp(&totp)?;
+            if clipboard {
+                if let Err(e) = clipboard_store(&totp) {
+                    eprintln!("{e}");
+                }
+            }
+            println!("{}", &totp);
+
         } else {
             return Err(anyhow::anyhow!(
                 "entry does not contain a totp secret"

--- a/src/bin/rbw/main.rs
+++ b/src/bin/rbw/main.rs
@@ -95,6 +95,8 @@ enum Opt {
         user: Option<String>,
         #[arg(long, help = "Folder name to search in")]
         folder: Option<String>,
+        #[structopt(long, help = "Copy result to clipboard")]
+        clipboard: bool,
     },
 
     #[command(
@@ -334,8 +336,8 @@ fn main() {
             *raw,
             *clipboard,
         ),
-        Opt::Code { name, user, folder } => {
-            commands::code(name, user.as_deref(), folder.as_deref())
+        Opt::Code { name, user, folder, clipboard } => {
+            commands::code(name, user.as_deref(), folder.as_deref(), *clipboard)
         }
         Opt::Add {
             name,

--- a/src/bin/rbw/main.rs
+++ b/src/bin/rbw/main.rs
@@ -87,8 +87,8 @@ enum Opt {
         clipboard: bool,
     },
 
-    #[command(about = "Display the authenticator code for a given entry")]
-    Code {
+    #[command(about = "Display the authenticator code for a given entry", visible_alias = "code")]
+    Otp {
         #[arg(help = "Name or UUID of the entry to display")]
         name: String,
         #[arg(help = "Username of the entry to display")]
@@ -246,7 +246,7 @@ impl Opt {
             Self::Sync => "sync".to_string(),
             Self::List { .. } => "list".to_string(),
             Self::Get { .. } => "get".to_string(),
-            Self::Code { .. } => "code".to_string(),
+            Self::Otp { .. } => "code".to_string(),
             Self::Add { .. } => "add".to_string(),
             Self::Generate { .. } => "generate".to_string(),
             Self::Edit { .. } => "edit".to_string(),
@@ -336,8 +336,8 @@ fn main() {
             *raw,
             *clipboard,
         ),
-        Opt::Code { name, user, folder, clipboard } => {
-            commands::code(name, user.as_deref(), folder.as_deref(), *clipboard)
+        Opt::Otp { name, user, folder, clipboard } => {
+            commands::otp(name, user.as_deref(), folder.as_deref(), *clipboard)
         }
         Opt::Add {
             name,


### PR DESCRIPTION
This pr implements functionality requested in #127 
 - Add support for copying (t)otp code to clipboard
 - Rename code to otp and add alias
