### PR TITLE
Add rbw-menu as a related project

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,3 +109,4 @@ the instructions [here](https://bitwarden.com/help/article/personal-api-key/).
 
 * [rofi-rbw](https://github.com/fdw/rofi-rbw): A rofi frontend for Bitwarden
 * [bw-ssh](https://framagit.org/Glandos/bw-ssh/): Manage SSH key passphrases in Bitwarden
+* [rbw-menu](https://github.com/rbuchberger/rbw-menu): Tiny menu picker for rbw


### PR DESCRIPTION
Hi! Firstly thanks for the project, it's awesome and I use it every day.

I've made an absolutely tiny bash script to wire rbw to fuzzy menus like wofi (which is the default). I'm not even sure it's complicated enough to share (it started out bigger and shrank as I figured out ways to simplify it), but I wanted to offer an alternative to rofi-rbw. That project is great, but it's like 1000 lines of python and I just wanted keybindings for copying credentials to the clipboard.

No hard feelings if you say no, I just thought it might be helpful. Thanks!

https://github.com/rbuchberger/rbw-menu