### PR TITLE
handle eof correctly when reading from pinentry

### DIFF
--- a/src/pinentry.rs
+++ b/src/pinentry.rs
@@ -137,6 +137,14 @@ where
                 .read(&mut data[len..])
                 .await
                 .map_err(|source| Error::PinentryReadOutput { source })?;
+            if bytes == 0 {
+                return Err(Error::PinentryReadOutput {
+                    source: std::io::Error::new(
+                        std::io::ErrorKind::UnexpectedEof,
+                        "unexpected EOF",
+                    ),
+                });
+            }
             len += bytes;
         }
     }


### PR DESCRIPTION
Just now rbw-agent will spin at 200% cores if pinentry fails, which can have various reasons. Now it will just terminate correctly when this happens.

This happens often to me when I close the terminal that runs pinentry.