### PR TITLE
Fix arch package URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ and merge pull requests implementing those features.
 ### Arch Linux
 
 `rbw` is available in the [community
-repository](https://archlinux.org/packages/community/x86_64/rbw/).
+repository](https://archlinux.org/packages/extra/x86_64/rbw/).
 Alternatively, you can install
 [`rbw-git`](https://aur.archlinux.org/packages/rbw-git/) from the AUR, which
 will always build from the latest master commit.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ and merge pull requests implementing those features.
 repository](https://archlinux.org/packages/extra/x86_64/rbw/).
 Alternatively, you can install
 [`rbw-git`](https://aur.archlinux.org/packages/rbw-git/) from the AUR, which
-will always build from the latest master commit.
+will always build from the latest `main` commit.
 
 ### Debian/Ubuntu
 


### PR DESCRIPTION
Apparently this was moved from community to extra at some point.
