### PR TITLE
Implement search functionality

### DIFF
--- a/src/bin/rbw/commands.rs
+++ b/src/bin/rbw/commands.rs
@@ -888,7 +888,7 @@ pub fn get(
 }
 
 pub fn search(
-    name: &str,
+    term: &str,
     user: Option<&str>,
     folder: Option<&str>,
     raw: bool,
@@ -900,10 +900,10 @@ pub fn search(
     let desc = format!(
         "{}{}",
         user.map_or_else(String::new, |s| format!("{s}@")),
-        name
+        term
     );
 
-    let found_name = find_entry_names(&db, name, user, folder)
+    let found_name = find_entry_names(&db, term, user, folder)
     .with_context(|| format!("No entries found for '{desc}'"))?;
 
     if raw {

--- a/src/bin/rbw/commands.rs
+++ b/src/bin/rbw/commands.rs
@@ -545,7 +545,7 @@ impl DecryptedCipher {
             }
         } else {
             let notes_value = self.notes.as_deref().unwrap_or("");
-            if !self.name.contains(name) & !notes_value.contains(name) {
+            if !self.name.contains(name) && !notes_value.contains(name) {
                 return false;
             }
         }
@@ -1498,7 +1498,8 @@ fn find_entries(
             .iter()
             .cloned()
             .filter(|(_, decrypted_cipher)| {
-                decrypted_cipher.partial_match(name, username, folder, false, true)
+                decrypted_cipher
+                    .partial_match(name, username, folder, false, true)
             })
             .map(|(_, DecryptedCipher)| DecryptedCipher)
             .collect();
@@ -1546,7 +1547,8 @@ fn find_entry_raw(
         .iter()
         .cloned()
         .filter(|(_, decrypted_cipher)| {
-            decrypted_cipher.partial_match(name, username, folder, true, false)
+            decrypted_cipher
+                .partial_match(name, username, folder, true, false)
         })
         .collect();
 
@@ -1559,7 +1561,8 @@ fn find_entry_raw(
             .iter()
             .cloned()
             .filter(|(_, decrypted_cipher)| {
-                decrypted_cipher.partial_match(name, username, folder, false, false)
+                decrypted_cipher
+                    .partial_match(name, username, folder, false, false)
             })
             .collect();
         if matches.len() == 1 {

--- a/src/bin/rbw/main.rs
+++ b/src/bin/rbw/main.rs
@@ -95,6 +95,8 @@ enum Opt {
         user: Option<String>,
         #[arg(long, help = "Folder name to search in")]
         folder: Option<String>,
+        #[arg(long, help = "Display the full entry in addition to the name")]
+        full: bool,
         #[structopt(long, help = "Display output as JSON")]
         raw: bool,
     },
@@ -351,11 +353,13 @@ fn main() {
             term,
             user,
             folder,
+            full,
             raw,
         } => commands::search(
             term,
             user.as_deref(),
             folder.as_deref(),
+            *full,
             *raw,
         ),
         Opt::Code { name, user, folder } => {

--- a/src/bin/rbw/main.rs
+++ b/src/bin/rbw/main.rs
@@ -87,6 +87,18 @@ enum Opt {
         clipboard: bool,
     },
 
+    #[command(about = "Search for the password for a given entry")]
+    Search {
+        #[arg(help = "Name or UUID of the entry to display")]
+        name: String,
+        #[arg(help = "Username of the entry to display")]
+        user: Option<String>,
+        #[arg(long, help = "Folder name to search in")]
+        folder: Option<String>,
+        #[structopt(long, help = "Display output as JSON")]
+        raw: bool,
+    },
+
     #[command(about = "Display the authenticator code for a given entry")]
     Code {
         #[arg(help = "Name or UUID of the entry to display")]
@@ -244,6 +256,7 @@ impl Opt {
             Self::Sync => "sync".to_string(),
             Self::List { .. } => "list".to_string(),
             Self::Get { .. } => "get".to_string(),
+            Self::Search { .. } => "search".to_string(),
             Self::Code { .. } => "code".to_string(),
             Self::Add { .. } => "add".to_string(),
             Self::Generate { .. } => "generate".to_string(),
@@ -333,6 +346,17 @@ fn main() {
             *full,
             *raw,
             *clipboard,
+        ),
+        Opt::Search {
+            name,
+            user,
+            folder,
+            raw,
+        } => commands::search(
+            name,
+            user.as_deref(),
+            folder.as_deref(),
+            *raw,
         ),
         Opt::Code { name, user, folder } => {
             commands::code(name, user.as_deref(), folder.as_deref())

--- a/src/bin/rbw/main.rs
+++ b/src/bin/rbw/main.rs
@@ -87,10 +87,10 @@ enum Opt {
         clipboard: bool,
     },
 
-    #[command(about = "Search for the password for a given entry")]
+    #[command(about = "Search for entries")]
     Search {
-        #[arg(help = "Name or UUID of the entry to display")]
-        name: String,
+        #[arg(help = "Search term to locate entries")]
+        term: String,
         #[arg(help = "Username of the entry to display")]
         user: Option<String>,
         #[arg(long, help = "Folder name to search in")]
@@ -348,12 +348,12 @@ fn main() {
             *clipboard,
         ),
         Opt::Search {
-            name,
+            term,
             user,
             folder,
             raw,
         } => commands::search(
-            name,
+            term,
             user.as_deref(),
             folder.as_deref(),
             *raw,


### PR DESCRIPTION
Attempts to close #114
Where `get` would display and error on multiple matches, search returns them all. With no additional arguments it lists the entry names. Using `--raw` works as expected to expected to display this as a json list. While `--full` displays the whole entry.

Adds new search command
  - returns list of entries
  - case insensitive searching

Modifies current get behavior to also search note content for matches

Never written rust before, so feedback is super welcome.

```
$ rbw search --help
Search for entries

Usage: rbw search [OPTIONS] <TERM> [USER]

Arguments:
  <TERM>  Search term to locate entries
  [USER]  Username of the entry to display

Options:
      --folder <FOLDER>  Folder name to search in
      --full             Display the full entry in addition to the name
      --raw              Display output as JSON
  -h, --help             Print help

```