### PR TITLE
Make directories when not daemonized

### DIFF
--- a/src/bin/rbw-agent/daemon.rs
+++ b/src/bin/rbw-agent/daemon.rs
@@ -18,8 +18,6 @@ impl Drop for StartupAck {
 }
 
 pub fn daemonize() -> anyhow::Result<StartupAck> {
-    rbw::dirs::make_all()?;
-
     let stdout = std::fs::OpenOptions::new()
         .append(true)
         .create(true)

--- a/src/bin/rbw-agent/main.rs
+++ b/src/bin/rbw-agent/main.rs
@@ -50,6 +50,8 @@ fn real_main() -> anyhow::Result<()> {
         .nth(1)
         .map_or(false, |arg| arg == "--no-daemonize");
 
+    rbw::dirs::make_all()?;
+
     let startup_ack = if no_daemonize {
         None
     } else {


### PR DESCRIPTION
I'm running `rbw-agent` with `--no-daemonize`, and that fails because the runtime directory for the socket file does not exist yet.

Related: #87