### PR TITLE
Corrected the base_url to reflect the changes on bitwarden.com - 'htt…

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ configuration options:
 * `email`: The email address to use as the account name when logging into the
   Bitwarden server. Required.
 * `base_url`: The URL of the Bitwarden server to use. Defaults to the official
-  server at `https://api.bitwarden.com/` if unset.
+  server at `https://vault.bitwarden.com/` if unset.
 * `identity_url`: The URL of the Bitwarden identity server to use. If unset,
   will use the `/identity` path on the configured `base_url`, or
   `https://identity.bitwarden.com/` if no `base_url` is set.


### PR DESCRIPTION
…ps://api.bitwarden.com' is not anymore valid and generate an error 'failed to log in to bitwarden instance: failed to parse JSON: EOF while parsing a value at line 1 column 0.' See issue #159.