### PR TITLE
Add CLI option for case-insensitive search.

### DIFF
--- a/src/bin/rbw/commands.rs
+++ b/src/bin/rbw/commands.rs
@@ -991,6 +991,7 @@ pub fn list(fields: &[String]) -> anyhow::Result<()> {
     Ok(())
 }
 
+#[allow(clippy::fn_params_excessive_bools)]
 pub fn get(
     needle: &Needle,
     user: Option<&str>,

--- a/src/bin/rbw/main.rs
+++ b/src/bin/rbw/main.rs
@@ -85,6 +85,8 @@ enum Opt {
         raw: bool,
         #[structopt(long, help = "Copy result to clipboard")]
         clipboard: bool,
+        #[structopt(short, long, help = "Ignore case")]
+        ignorecase: bool,
     },
 
     #[command(
@@ -100,6 +102,8 @@ enum Opt {
         folder: Option<String>,
         #[structopt(long, help = "Copy result to clipboard")]
         clipboard: bool,
+        #[arg(short, long, help = "Ignore case")]
+        ignorecase: bool,
     },
 
     #[command(
@@ -198,6 +202,8 @@ enum Opt {
         user: Option<String>,
         #[arg(long, help = "Folder name to search in")]
         folder: Option<String>,
+        #[arg(short, long, help = "Ignore case")]
+        ignorecase: bool,
     },
 
     #[command(about = "Remove a given entry", visible_alias = "rm")]
@@ -208,6 +214,8 @@ enum Opt {
         user: Option<String>,
         #[arg(long, help = "Folder name to search in")]
         folder: Option<String>,
+        #[arg(short, long, help = "Ignore case")]
+        ignorecase: bool,
     },
 
     #[command(about = "View the password history for a given entry")]
@@ -218,6 +226,8 @@ enum Opt {
         user: Option<String>,
         #[arg(long, help = "Folder name to search in")]
         folder: Option<String>,
+        #[arg(short, long, help = "Ignore case")]
+        ignorecase: bool,
     },
 
     #[command(about = "Lock the password database")]
@@ -330,6 +340,7 @@ fn main() {
             full,
             raw,
             clipboard,
+            ignorecase,
         } => commands::get(
             needle,
             user.as_deref(),
@@ -338,17 +349,20 @@ fn main() {
             *full,
             *raw,
             *clipboard,
+            *ignorecase,
         ),
         Opt::Code {
             needle,
             user,
             folder,
             clipboard,
+            ignorecase,
         } => commands::code(
             needle,
             user.as_deref(),
             folder.as_deref(),
             *clipboard,
+            *ignorecase,
         ),
         Opt::Add {
             name,
@@ -400,15 +414,39 @@ fn main() {
                 ty,
             )
         }
-        Opt::Edit { name, user, folder } => {
-            commands::edit(name, user.as_deref(), folder.as_deref())
-        }
-        Opt::Remove { name, user, folder } => {
-            commands::remove(name, user.as_deref(), folder.as_deref())
-        }
-        Opt::History { name, user, folder } => {
-            commands::history(name, user.as_deref(), folder.as_deref())
-        }
+        Opt::Edit {
+            name,
+            user,
+            folder,
+            ignorecase,
+        } => commands::edit(
+            name,
+            user.as_deref(),
+            folder.as_deref(),
+            *ignorecase,
+        ),
+        Opt::Remove {
+            name,
+            user,
+            folder,
+            ignorecase,
+        } => commands::remove(
+            name,
+            user.as_deref(),
+            folder.as_deref(),
+            *ignorecase,
+        ),
+        Opt::History {
+            name,
+            user,
+            folder,
+            ignorecase,
+        } => commands::history(
+            name,
+            user.as_deref(),
+            folder.as_deref(),
+            *ignorecase,
+        ),
         Opt::Lock => commands::lock(),
         Opt::Purge => commands::purge(),
         Opt::StopAgent => commands::stop_agent(),


### PR DESCRIPTION
Hi @doy,

I have implemented a CLI option for case-insensitive name search (#144), as this is the one feature I miss from `rbw`.

I would be happy to adapt the PR with your suggestions.