### PR TITLE
Support UUIDs and URIs in code command

### DIFF
--- a/src/bin/rbw/commands.rs
+++ b/src/bin/rbw/commands.rs
@@ -1018,7 +1018,7 @@ pub fn get(
 }
 
 pub fn code(
-    name: &str,
+    needle: &Needle,
     user: Option<&str>,
     folder: Option<&str>,
     clipboard: bool,
@@ -1030,12 +1030,11 @@ pub fn code(
     let desc = format!(
         "{}{}",
         user.map_or_else(String::new, |s| format!("{s}@")),
-        name
+        needle
     );
 
-    let (_, decrypted) =
-        find_entry(&db, &Needle::Name(name.to_string()), user, folder)
-            .with_context(|| format!("couldn't find entry for '{desc}'"))?;
+    let (_, decrypted) = find_entry(&db, needle, user, folder)
+        .with_context(|| format!("couldn't find entry for '{desc}'"))?;
 
     if let DecryptedData::Login { totp, .. } = decrypted.data {
         if let Some(totp) = totp {

--- a/src/bin/rbw/main.rs
+++ b/src/bin/rbw/main.rs
@@ -92,8 +92,8 @@ enum Opt {
         visible_alias = "totp"
     )]
     Code {
-        #[arg(help = "Name or UUID of the entry to display")]
-        name: String,
+        #[arg(help = "Name, URI or UUID of the entry to display", value_parser = commands::parse_needle)]
+        needle: commands::Needle,
         #[arg(help = "Username of the entry to display")]
         user: Option<String>,
         #[arg(long, help = "Folder name to search in")]
@@ -340,12 +340,12 @@ fn main() {
             *clipboard,
         ),
         Opt::Code {
-            name,
+            needle,
             user,
             folder,
             clipboard,
         } => commands::code(
-            name,
+            needle,
             user.as_deref(),
             folder.as_deref(),
             *clipboard,


### PR DESCRIPTION
a864366e60f6e7ae67df91010d7e30f3b1569ac0 changed the implementation of
`find_entry` to work on the new `Needle` type, but when calling into it from the
`code` subcommand the provided string was only passed as a `Needle::Name` when
in fact also UUIDs are allowed.

Remedy this by parsing the first argument in the same way as with the `get`
command, which also enables passing URIs

Signed-off-by: Robert Günzler <r@gnzler.io>
