### PR TITLE
Add support for SSO login

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,6 +127,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
+name = "axum"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a6c9af12842a67734c9a2e355436e5d03b22383ed60cf13cd0c18fbfe3dcbcf"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.1",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15c63fd72d41492dc4f497196f5da1fb04fb7529e631d73630d1b491e47a2e3"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper 0.1.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -745,6 +800,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -762,6 +823,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -905,7 +967,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -963,6 +1025,12 @@ checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "memchr"
@@ -1340,6 +1408,7 @@ dependencies = [
  "argon2",
  "arrayvec",
  "async-trait",
+ "axum",
  "base32",
  "base64",
  "block-padding",
@@ -1482,7 +1551,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -1557,9 +1626,9 @@ checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustix"
-version = "0.38.34"
+version = "0.38.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+checksum = "e3cc72858054fcff6d7dea32df2aeaee6a7c24227366d7ea429aada2f26b16ad"
 dependencies = [
  "bitflags 2.5.0",
  "errno",
@@ -1623,6 +1692,12 @@ dependencies = [
  "rustls-pki-types",
  "untrusted",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "ryu"
@@ -1896,6 +1971,12 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -833,6 +833,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -841,6 +850,16 @@ dependencies = [
  "hermit-abi",
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
 ]
 
 [[package]]
@@ -1088,6 +1107,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "open"
+version = "5.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "449f0ff855d85ddbf1edd5b646d65249ead3f5e422aaa86b7d2d0b049b103e32"
+dependencies = [
+ "is-wsl",
+ "libc",
+ "pathdiff",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1132,6 +1162,12 @@ name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "pbkdf2"
@@ -1323,6 +1359,7 @@ dependencies = [
  "is-terminal",
  "libc",
  "log",
+ "open",
  "pbkdf2",
  "percent-encoding",
  "pkcs8",
@@ -1348,6 +1385,7 @@ dependencies = [
  "tokio-tungstenite",
  "totp-lite",
  "url",
+ "urlencoding",
  "uuid",
  "zeroize",
 ]
@@ -2137,6 +2175,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf-8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,8 @@ tokio-tungstenite = { version = "0.21", features = ["rustls-tls-native-roots"] }
 is-terminal = "0.4.12"
 regex = "1.10.4"
 rustix = { version = "0.38.33", features = ["termios", "procfs", "process", "pipe"] }
+open = "5.1.2"
+urlencoding = "2.1.3"
 
 [package.metadata.deb]
 depends = "pinentry"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ regex = "1.10.4"
 rustix = { version = "0.38.33", features = ["termios", "procfs", "process", "pipe"] }
 open = "5.1.2"
 urlencoding = "2.1.3"
+axum = "0.7.5"
 
 [package.metadata.deb]
 depends = "pinentry"

--- a/README.md
+++ b/README.md
@@ -66,11 +66,14 @@ configuration options:
 
 * `email`: The email address to use as the account name when logging into the
   Bitwarden server. Required.
+* `sso_id`: The SSO organization ID. Defaults to regular login process if unset.
 * `base_url`: The URL of the Bitwarden server to use. Defaults to the official
   server at `https://api.bitwarden.com/` if unset.
 * `identity_url`: The URL of the Bitwarden identity server to use. If unset,
   will use the `/identity` path on the configured `base_url`, or
   `https://identity.bitwarden.com/` if no `base_url` is set.
+* `ui_url`: The URL of the Bitwarden UI to use. If unset,
+  will default to `https://vault.bitwarden.com/`.
 * `notifications_url`: The URL of the Bitwarden notifications server to use.
   If unset, will use the `/notifications` path on the configured `base_url`,
   or `https://notifications.bitwarden.com/` if no `base_url` is set.

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -42,6 +42,7 @@ pub async fn login(
     let (access_token, refresh_token, protected_key) = client
         .login(
             email,
+            config.sso_id.as_deref(),
             &crate::config::device_id(&config).await?,
             &identity.master_password_hash,
             two_factor_token,
@@ -336,6 +337,7 @@ fn api_client() -> Result<(crate::api::Client, crate::config::Config)> {
     let client = crate::api::Client::new(
         &config.base_url(),
         &config.identity_url(),
+        &config.ui_url(),
         config.client_cert_path(),
     );
     Ok((client, config))
@@ -347,6 +349,7 @@ async fn api_client_async(
     let client = crate::api::Client::new(
         &config.base_url(),
         &config.identity_url(),
+        &config.ui_url(),
         config.client_cert_path(),
     );
     Ok((client, config))

--- a/src/api.rs
+++ b/src/api.rs
@@ -1448,7 +1448,7 @@ impl Client {
     ) -> Result<String> {
         let connect_req = ConnectRefreshTokenReq {
             grant_type: "refresh_token".to_string(),
-            client_id: "desktop".to_string(),
+            client_id: "cli".to_string(),
             refresh_token: refresh_token.to_string(),
         };
         let client = reqwest::blocking::Client::new();
@@ -1467,7 +1467,7 @@ impl Client {
     ) -> Result<String> {
         let connect_req = ConnectRefreshTokenReq {
             grant_type: "refresh_token".to_string(),
-            client_id: "desktop".to_string(),
+            client_id: "cli".to_string(),
             refresh_token: refresh_token.to_string(),
         };
         let client = self.reqwest_client().await?;

--- a/src/bin/rbw/commands.rs
+++ b/src/bin/rbw/commands.rs
@@ -823,8 +823,10 @@ pub fn config_set(key: &str, value: &str) -> anyhow::Result<()> {
         .unwrap_or_else(|_| rbw::config::Config::new());
     match key {
         "email" => config.email = Some(value.to_string()),
+        "sso_id" => config.sso_id = Some(value.to_string()),
         "base_url" => config.base_url = Some(value.to_string()),
         "identity_url" => config.identity_url = Some(value.to_string()),
+        "ui_url" => config.ui_url = Some(value.to_string()),
         "notifications_url" => {
             config.notifications_url = Some(value.to_string());
         }
@@ -868,8 +870,10 @@ pub fn config_unset(key: &str) -> anyhow::Result<()> {
         .unwrap_or_else(|_| rbw::config::Config::new());
     match key {
         "email" => config.email = None,
+        "sso_id" => config.sso_id = None,
         "base_url" => config.base_url = None,
         "identity_url" => config.identity_url = None,
+        "ui_url" => config.ui_url = None,
         "notifications_url" => config.notifications_url = None,
         "client_cert_path" => config.client_cert_path = None,
         "lock_timeout" => {

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,8 +6,10 @@ use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 #[derive(serde::Serialize, serde::Deserialize, Debug)]
 pub struct Config {
     pub email: Option<String>,
+    pub sso_id: Option<String>,
     pub base_url: Option<String>,
     pub identity_url: Option<String>,
+    pub ui_url: Option<String>,
     pub notifications_url: Option<String>,
     #[serde(default = "default_lock_timeout")]
     pub lock_timeout: u64,
@@ -25,8 +27,10 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             email: None,
+            sso_id: None,
             base_url: None,
             identity_url: None,
+            ui_url: None,
             notifications_url: None,
             lock_timeout: default_lock_timeout(),
             sync_interval: default_sync_interval(),
@@ -172,6 +176,14 @@ impl Config {
                 },
             )
         })
+    }
+
+    #[must_use]
+    pub fn ui_url(&self) -> String {
+        // TODO: default to either vault.bitwarden.com or vault.bitwarden.eu based on the base_url?
+        self.ui_url
+            .clone()
+            .unwrap_or_else(|| "https://vault.bitwarden.com".to_string())
     }
 
     #[must_use]

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,11 +18,23 @@ pub enum Error {
     #[error("failed to create reqwest client")]
     CreateReqwestClient { source: reqwest::Error },
 
+    #[error("failed to create sso callback server: {err}")]
+    CreateSSOCallbackServer { err: std::io::Error },
+
     #[error("failed to decrypt")]
     Decrypt { source: block_padding::UnpadError },
 
+    #[error("failed to find free port in {range}")]
+    FailedToFindFreePort { range: String },
+
     #[error("failed to parse pinentry output ({out:?})")]
     FailedToParsePinentry { out: String },
+
+    #[error("failed to process sso callback ({msg})")]
+    FailedToProcessSSOCallback { msg: String },
+
+    #[error("failed to open web browser: {err}")]
+    FailedToOpenWebBrowser { err: std::io::Error },
 
     #[error("failed to read from stdin: {err}")]
     FailedToReadFromStdin { err: std::io::Error },
@@ -213,6 +225,11 @@ pub enum Error {
 
     #[error("error spawning pinentry")]
     Spawn { source: tokio::io::Error },
+
+    #[error(
+        "sso callback received state does not match the sent one ({msg})"
+    )]
+    SSOCallbackStatesDoNotMatch { msg: String },
 
     #[error("cipherstring type {ty} too old\n\nPlease rotate your account encryption key (https://bitwarden.com/help/article/account-encryption-key/) and try again.")]
     TooOldCipherStringType { ty: String },

--- a/src/error.rs
+++ b/src/error.rs
@@ -226,11 +226,6 @@ pub enum Error {
     #[error("error spawning pinentry")]
     Spawn { source: tokio::io::Error },
 
-    #[error(
-        "sso callback received state does not match the sent one ({msg})"
-    )]
-    SSOCallbackStatesDoNotMatch { msg: String },
-
     #[error("cipherstring type {ty} too old\n\nPlease rotate your account encryption key (https://bitwarden.com/help/article/account-encryption-key/) and try again.")]
     TooOldCipherStringType { ty: String },
 


### PR DESCRIPTION
Resolves https://github.com/doy/rbw/issues/118

Implementation is mostly ported from the [official CLI](https://github.com/bitwarden/clients/blob/main/apps/cli/src/auth/commands/login.command.ts#L109), with minor changes to utilise having predefined `sso_id` in the config file.

Tested with Google based SSO.

### Auth flow
Can be summarised with:
1. Generate two random values, `state` and `ssoCodeVerifier`
2. hash and B64 escape the `ssoCodeVerifier`
3. spin up a local callback server (I assume port range is important here because of the allowed `redirect_uris` on Bitwarden end)
4. open a webbrowser initializing the SSO flow using the previously generated values
5. obtain the `authorization_code` via the callback server
6. replace the code for tokens by calling the `/identity/token` endpoint (same as for passwords, but different params)

### Quirks
#### 2FA
Due to the way 2FA is implemented in `rbw` (try to authenticate without 2FA, fallback to it as needed based on the response from server) SSO users with 2FA configured have to go through the "webbrowser flow" twice: once to get the response about the missing 2FA, second time to send 2FA alongside the SSO obtained code.
Bitwarden CLI reuses the authorization_code obtained in first iteration in such cases, but I feel this approach would require bigger overhaul in `rbw`.

#### Password
SSO flow doesn't use the master password in its auth, so theoretically we don't have to ask for it during `login`.
Of course it's still required for the `unlock` operation.

I kept the master password prompt in SSO flow to be in sync with the password flow, which automatically calls `unlock` after `login`.

### Notes
Usual disclaimer: I don't really write Rust, feel free to suggest more idiomatic code wherever you see fit.
Especially the error handling feels like it could use some improvements