### PR TITLE
Add new headers required by the Bitwarden server

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -895,6 +895,8 @@ impl Client {
         let res = client
             .post(&self.identity_url("/connect/token"))
             .form(&connect_req)
+            .header("Bitwarden-Client-Name", env!("CARGO_PKG_NAME"))
+            .header("Bitwarden-Client-Version", env!("CARGO_PKG_VERSION"))
             .header(
                 "auth-email",
                 crate::base64::encode_url_safe_no_pad(email),


### PR DESCRIPTION
Since recently, official Bitwarden server started rejecting authentication requests to the `/connect/token` endpoint if they do not have specific HTTP headers set.

FTR, as of now, values of these headers do not seem to matter.

Fixes #173 