### PR TITLE
fix rbw-pinentry-keyring not saving passwords correctly and not working with 2fa codes and add auto setup

### DIFF
--- a/bin/rbw-pinentry-keyring
+++ b/bin/rbw-pinentry-keyring
@@ -35,18 +35,40 @@ function setup() {
 function getpin() {
     echo 'OK'
 
+    title=""
+    prompt=""
+    desc=""
+
     while IFS=' ' read -r command args ; do
         case "$command" in
-            SETPROMPT|SETTITLE| SETDESC)
+            SETTITLE)
+                title="$args"
+                echo 'OK'
+                ;;
+            SETDESC)
+                desc="$args"
+                echo 'OK'
+                ;;
+            SETPROMPT)
+                prompt="$args"
                 echo 'OK'
                 ;;
             GETPIN)
-                secret_value="$(secret-tool lookup application rbw profile "$rbw_profile" type master_password)"
-                if [ -z "$secret_value" ]; then
-                    exit 1
+                if [[ "$prompt" == "Master Password" ]]; then 
+                    secret_value="$(secret-tool lookup application rbw profile "$rbw_profile" type master_password)"
+                    if [ -z "$secret_value" ]; then
+                        exit 1
+                    fi
+                    printf 'D %s\n' "$secret_value"
+                    echo 'OK'
+                else
+                    cmd="SETTITLE $title\n"
+                    cmd+="SETPROMPT $prompt\n"
+                    cmd+="SETDESC $desc\n"
+                    cmd+="GETPIN\n"
+
+                    printf "$cmd" | pinentry
                 fi
-                printf 'D %s\n' "$secret_value"
-                echo 'OK'
                 ;;
             BYE)
                 exit

--- a/bin/rbw-pinentry-keyring
+++ b/bin/rbw-pinentry-keyring
@@ -9,7 +9,7 @@ function help() {
 Use this script as pinentry to store master password for rbw into your keyring
 
 Usage
-- run "rbw-pinentry-keyring setup" once to save master password to keyring
+- run "rbw-pinentry-keyring clear" to clear the master password from your keyring 
 - add "rbw-pinentry-keyring" as "pinentry" in rbw config (${XDG_CONFIG_HOME}/rbw/config.json)
 - use rbw as normal
 Notes
@@ -21,15 +21,8 @@ Notes
 EOHELP
 }
 
-function setup() {
-    cmd="SETTITLE rbw\n"
-    cmd+="SETPROMPT Master Password\n"
-    cmd+="SETDESC Please enter the master password for '$rbw_profile'\n"
-    cmd+="GETPIN\n"
-    password="$(printf "$cmd" | pinentry | grep -E "^D " | cut -c3-)"
-    if [ -n "$password" ]; then
-        echo -n "$password" | secret-tool store --label="$rbw_profile master password" application rbw profile "$rbw_profile" type master_password
-    fi
+function clear() {
+    secret-tool clear application rbw profile "$rbw_profile" type master_password
 }
 
 function getpin() {
@@ -54,11 +47,23 @@ function getpin() {
                 echo 'OK'
                 ;;
             GETPIN)
-                if [[ "$prompt" == "Master Password" ]]; then 
+                if [[ "$prompt" == "Master Password" ]]; then
+                    set +e
                     secret_value="$(secret-tool lookup application rbw profile "$rbw_profile" type master_password)"
-                    if [ -z "$secret_value" ]; then
-                        exit 1
+                    err=$?
+                    set -e
+
+                    if [[ $err == 1 ]]; then
+                        cmd="SETTITLE rbw\n"
+                        cmd+="SETPROMPT Master Password\n"
+                        cmd+="SETDESC Please enter the master password for '$rbw_profile'\n"
+                        cmd+="GETPIN\n"
+                        secret_value="$(printf "$cmd" | pinentry | grep -E "^D " | cut -c3-)"
+                        if [ -n "$secret_value" ]; then
+                            echo -n "$secret_value" | secret-tool store --label="$rbw_profile master password" application rbw profile "$rbw_profile" type master_password >/dev/null 2>&1
+                        fi
                     fi
+
                     printf 'D %s\n' "$secret_value"
                     echo 'OK'
                 else
@@ -67,7 +72,10 @@ function getpin() {
                     cmd+="SETDESC $desc\n"
                     cmd+="GETPIN\n"
 
-                    printf "$cmd" | pinentry
+                    secret_value="$(printf "$cmd" | pinentry | grep -E "^D " | cut -c3-)"
+
+                    printf 'D %s\n' "$secret_value"
+                    echo 'OK'
                 fi
                 ;;
             BYE)
@@ -85,8 +93,8 @@ case "$command" in
     -h|--help|help)
         help
         ;;
-    -s|--setup|setup)
-        setup
+    -c|--clear|clear)
+        clear
         ;;
     *)
         getpin

--- a/bin/rbw-pinentry-keyring
+++ b/bin/rbw-pinentry-keyring
@@ -26,7 +26,7 @@ function setup() {
     cmd+="SETPROMPT Master Password\n"
     cmd+="SETDESC Please enter the master password for '$rbw_profile'\n"
     cmd+="GETPIN\n"
-    password="$(printf "$cmd" | pinentry | grep -E "^D " | cut -d' ' -f2)"
+    password="$(printf "$cmd" | pinentry | grep -E "^D " | cut -c3-)"
     if [ -n "$password" ]; then
         echo -n "$password" | secret-tool store --label="$rbw_profile master password" application rbw profile "$rbw_profile" type master_password
     fi


### PR DESCRIPTION
This PR solves 3 things:

1. 
the rbw-pinentry-keyring setup command did not support passwords that includes a space. The cut command only retrieved the first word of the password and thus skipping the other words. `cut -c3-` cuts from the 3rd char 'D ' to the end of the line. 

So pinentry output like `D this is a passphrase` will be cut to `this is a passphrase`.

Can be tested with the following commands:

old: `echo "D this is a passphrase" | cut -d' ' -f2`
new: `echo "D this is a passphrase" | cut -c3-`

2.
Also the script doesnt work with 2fa codes because the secret-tool is called for the 2fa code instead of the system pinentry. This PR also fixes that bug.

3.
This PR also removes the setup command and it will auto setup if the password is not found in the keyring. Also there is a new command added: `clear`, with this command the password can be cleared from the keyring in case it needs to be updated or removed.