### PR TITLE
fix incorrect "Username or password is incorrect" error

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -875,7 +875,7 @@ impl Client {
             username: email.to_string(),
             password: Some(crate::base64::encode(password_hash.hash())),
             scope: "api offline_access".to_string(),
-            client_id: "desktop".to_string(),
+            client_id: "browser".to_string(),
             client_secret: None,
             device_type: 8,
             device_identifier: device_id.to_string(),
@@ -1322,7 +1322,7 @@ impl Client {
     ) -> Result<String> {
         let connect_req = ConnectRefreshTokenReq {
             grant_type: "refresh_token".to_string(),
-            client_id: "desktop".to_string(),
+            client_id: "browser".to_string(),
             refresh_token: refresh_token.to_string(),
         };
         let client = reqwest::blocking::Client::new();
@@ -1341,7 +1341,7 @@ impl Client {
     ) -> Result<String> {
         let connect_req = ConnectRefreshTokenReq {
             grant_type: "refresh_token".to_string(),
-            client_id: "desktop".to_string(),
+            client_id: "browser".to_string(),
             refresh_token: refresh_token.to_string(),
         };
         let client = self.reqwest_client().await?;


### PR DESCRIPTION
Hi,

I hacked together a proxy that basically proxies everything bitwarden related on my machine and prints the various requests and responses. I then logged in to bitwarden via the Firefox extension which works (no surprises there) and looked at the logs from my proxy and started comparing each request with what rbw is doing.

I noticed that the `client_id` query parameter in the `/connect/token` request is set to `desktop` but the Firefox extension is setting it to `browser`. After changing to `browser` I am now able to login again and I am not getting the "Username or password is incorrect" message.

This PR fixes https://github.com/doy/rbw/issues/182