### PR TITLE
fix: use "cli" as client id when logging in, fixes #182

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -875,7 +875,7 @@ impl Client {
             username: email.to_string(),
             password: Some(crate::base64::encode(password_hash.hash())),
             scope: "api offline_access".to_string(),
-            client_id: "desktop".to_string(),
+            client_id: "cli".to_string(),
             client_secret: None,
             device_type: 8,
             device_identifier: device_id.to_string(),
@@ -1322,7 +1322,7 @@ impl Client {
     ) -> Result<String> {
         let connect_req = ConnectRefreshTokenReq {
             grant_type: "refresh_token".to_string(),
-            client_id: "desktop".to_string(),
+            client_id: "cli".to_string(),
             refresh_token: refresh_token.to_string(),
         };
         let client = reqwest::blocking::Client::new();
@@ -1341,7 +1341,7 @@ impl Client {
     ) -> Result<String> {
         let connect_req = ConnectRefreshTokenReq {
             grant_type: "refresh_token".to_string(),
-            client_id: "desktop".to_string(),
+            client_id: "cli".to_string(),
             refresh_token: refresh_token.to_string(),
         };
         let client = self.reqwest_client().await?;


### PR DESCRIPTION
the official bitwarden cli uses the following parameters when logging in (POST /connect/token):

```
scope=api offline_access
client_id=cli
deviceType=25
deviceIdentifier=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
deviceName=linux
grant_type=password
username=xxxxxxxxxxxxxxxxxxxxxxxxx
password=xxxxxxxxxxxxxxxxxxxxxxxxx
```

before this commit, rbw uses these parameters:

```
scope=api offline_access
client_id=desktop
deviceType=8
deviceIdentifier=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
deviceName=rbw
devicePushToken=
grant_type=password
username=xxxxxxxxxxxxxxxxxxxxxxxxx
password=xxxxxxxxxxxxxxxxxxxxxxxxx
```

although there are multiple differences, changing the client id from "desktop" to "cli" is sufficient to fix the issue.