### PR TITLE
fix `rbw code: totp secret was not valid base32`

### DIFF
--- a/src/bin/rbw/commands.rs
+++ b/src/bin/rbw/commands.rs
@@ -2114,7 +2114,7 @@ struct TotpParams {
 fn decode_totp_secret(secret: &str) -> anyhow::Result<Vec<u8>> {
     base32::decode(
         base32::Alphabet::Rfc4648 { padding: false },
-        &secret.replace(' ', ""),
+        &secret.replace(' ', "").to_uppercase(),
     )
     .ok_or_else(|| anyhow::anyhow!("totp secret was not valid base32"))
 }


### PR DESCRIPTION
After a recent update, most of my TOTP secrets stopped working, with the message:

```
rbw code: totp secret was not valid base32
```

I found that it's because they must be uppercase now. 

This patch makes the secret uppercase, before decoding, which resolves the issue for me.