### PR TITLE
Fix: Continue sync and lock timer during system sleep 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /pkg
 /target
 /target-ra
+
+.idea


### PR DESCRIPTION
This commit fixes a bug were the timers for sync and vault lock did not "continue" during system sleep because of the use of `tokio::time::sleep` which uses the monotonic clock.

Did only test on Linux, although according to https://doc.rust-lang.org/std/time/struct.SystemTime.html#platform-specific-behavior, `SystemTime` works on all platforms.

As SystemTime can be manipulated by the user, the timers elapse completely when time went backwards for security reasons.