### PR TITLE
Fix JSON parsing: make field type optional

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -683,7 +683,7 @@ pub enum LinkedIdType {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
 struct CipherField {
     #[serde(rename = "Type", alias = "type")]
-    ty: FieldType,
+    ty: Option<FieldType>,
     #[serde(rename = "Name", alias = "name")]
     name: Option<String>,
     #[serde(rename = "Value", alias = "value")]

--- a/src/bin/rbw/commands.rs
+++ b/src/bin/rbw/commands.rs
@@ -742,24 +742,29 @@ struct DecryptedField {
     name: Option<String>,
     value: Option<String>,
     #[serde(serialize_with = "serialize_field_type", rename = "type")]
-    ty: rbw::api::FieldType,
+    ty: Option<rbw::api::FieldType>,
 }
 
 #[allow(clippy::trivially_copy_pass_by_ref)]
 fn serialize_field_type<S>(
-    ty: &rbw::api::FieldType,
+    ty: &Option<rbw::api::FieldType>,
     serializer: S,
 ) -> Result<S::Ok, S::Error>
 where
     S: serde::Serializer,
 {
-    let s = match ty {
-        rbw::api::FieldType::Text => "text",
-        rbw::api::FieldType::Hidden => "hidden",
-        rbw::api::FieldType::Boolean => "boolean",
-        rbw::api::FieldType::Linked => "linked",
-    };
-    serializer.serialize_str(s)
+    match ty {
+        Some(ty) => {
+            let s = match ty {
+                rbw::api::FieldType::Text => "text",
+                rbw::api::FieldType::Hidden => "hidden",
+                rbw::api::FieldType::Boolean => "boolean",
+                rbw::api::FieldType::Linked => "linked",
+            };
+            serializer.serialize_some(&Some(s))
+        }
+        None => serializer.serialize_none(),
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/src/db.rs
+++ b/src/db.rs
@@ -148,7 +148,7 @@ pub enum EntryData {
     serde::Serialize, serde::Deserialize, Debug, Clone, Eq, PartialEq,
 )]
 pub struct Field {
-    pub ty: crate::api::FieldType,
+    pub ty: Option<crate::api::FieldType>,
     pub name: Option<String>,
     pub value: Option<String>,
     pub linked_id: Option<crate::api::LinkedIdType>,


### PR DESCRIPTION
I'm getting the following error on `rbw sync`:
```sh
rbw get: failed to sync database from server: failed to parse JSON: ciphers[21].fields[0]: missing field `Type` at line 1 column 45441
```
which is complaining about missing field `Type`. 

After the changes from PR, I was able to inspect the actual raw JSON from bitwarden server, and the offending json objects are due to the optional "type" field
```sh
$ rbw get SSH-KEY_core --raw
```
```json
{
  "id": "...",
  "folder": null,
  "name": "SSH-KEY_core",
  "data": null,
  "fields": [
    {
      "name": "custom-type",
      "value": "ssh-key",
      "type": null
    },
    {
      "name": "public-key",
      "value": "...",
      "type": null
    },
    {
      "name": "private-key",
      "value": "...",
      "type": "hidden"
    }
  ],
  "history": []
}
```
The json are set via API call as opposed to via GUI, hence it's possible to not specify the field "type".

Just FYI, both the web interface and chrome extension works with the missing fields, where it will displays as follows:

![image](https://github.com/user-attachments/assets/d613998b-9701-481c-8285-6b47282b6adb)

I.e., it will just display nothing (neither text value nor as hidden). So `rbw` should also accept the schema as it's accepted by the server.
