### PR TITLE
Pass environment variables from rbw to rbw-agent

### DIFF
--- a/bin/rbw-pinentry-keyring
+++ b/bin/rbw-pinentry-keyring
@@ -58,7 +58,7 @@ function getpin() {
                         cmd+="SETPROMPT Master Password\n"
                         cmd+="SETDESC Please enter the master password for '$rbw_profile'\n"
                         cmd+="GETPIN\n"
-                        secret_value="$(printf "$cmd" | pinentry | grep -E "^D " | cut -c3-)"
+                        secret_value="$(printf "$cmd" | pinentry "$@" | grep -E "^D " | cut -c3-)"
                         if [ -n "$secret_value" ]; then
                             echo -n "$secret_value" | secret-tool store --label="$rbw_profile master password" application rbw profile "$rbw_profile" type master_password >/dev/null 2>&1
                         fi
@@ -72,7 +72,7 @@ function getpin() {
                     cmd+="SETDESC $desc\n"
                     cmd+="GETPIN\n"
 
-                    secret_value="$(printf "$cmd" | pinentry | grep -E "^D " | cut -c3-)"
+                    secret_value="$(printf "$cmd" | pinentry "$@" | grep -E "^D " | cut -c3-)"
 
                     printf 'D %s\n' "$secret_value"
                     echo 'OK'
@@ -97,6 +97,6 @@ case "$command" in
         clear
         ;;
     *)
-        getpin
+        getpin "$@"
         ;;
 esac

--- a/src/bin/rbw-agent/actions.rs
+++ b/src/bin/rbw-agent/actions.rs
@@ -2,7 +2,7 @@ use anyhow::Context as _;
 
 pub async fn register(
     sock: &mut crate::sock::Sock,
-    tty: Option<&str>,
+    environment: &rbw::protocol::Environment,
 ) -> anyhow::Result<()> {
     let db = load_db().await.unwrap_or_else(|_| rbw::db::Db::new());
 
@@ -33,7 +33,7 @@ pub async fn register(
                 "API key client__id",
                 &format!("Log in to {host}"),
                 err.as_deref(),
-                tty,
+                environment,
                 false,
             )
             .await
@@ -43,7 +43,7 @@ pub async fn register(
                 "API key client__secret",
                 &format!("Log in to {host}"),
                 err.as_deref(),
-                tty,
+                environment,
                 false,
             )
             .await
@@ -79,7 +79,7 @@ pub async fn register(
 pub async fn login(
     sock: &mut crate::sock::Sock,
     state: std::sync::Arc<tokio::sync::Mutex<crate::agent::State>>,
-    tty: Option<&str>,
+    environment: &rbw::protocol::Environment,
 ) -> anyhow::Result<()> {
     let db = load_db().await.unwrap_or_else(|_| rbw::db::Db::new());
 
@@ -110,7 +110,7 @@ pub async fn login(
                 "Master Password",
                 &format!("Log in to {host}"),
                 err.as_deref(),
-                tty,
+                environment,
                 true,
             )
             .await
@@ -161,7 +161,7 @@ pub async fn login(
                                 parallelism,
                                 protected_key,
                             ) = two_factor(
-                                tty,
+                                environment,
                                 &email,
                                 password.clone(),
                                 provider,
@@ -212,7 +212,7 @@ pub async fn login(
 }
 
 async fn two_factor(
-    tty: Option<&str>,
+    environment: &rbw::protocol::Environment,
     email: &str,
     password: rbw::locked::Password,
     provider: rbw::api::TwoFactorProviderType,
@@ -239,7 +239,7 @@ async fn two_factor(
             provider.header(),
             provider.message(),
             err.as_deref(),
-            tty,
+            environment,
             provider.grab(),
         )
         .await
@@ -363,7 +363,7 @@ async fn login_success(
 pub async fn unlock(
     sock: &mut crate::sock::Sock,
     state: std::sync::Arc<tokio::sync::Mutex<crate::agent::State>>,
-    tty: Option<&str>,
+    environment: &rbw::protocol::Environment,
 ) -> anyhow::Result<()> {
     if state.lock().await.needs_unlock() {
         let db = load_db().await?;
@@ -411,7 +411,7 @@ pub async fn unlock(
                     rbw::dirs::profile()
                 ),
                 err.as_deref(),
-                tty,
+                environment,
                 true,
             )
             .await

--- a/src/bin/rbw-agent/agent.rs
+++ b/src/bin/rbw-agent/agent.rs
@@ -195,16 +195,16 @@ async fn handle_request(
     };
     let set_timeout = match &req.action {
         rbw::protocol::Action::Register => {
-            crate::actions::register(sock, req.tty.as_deref()).await?;
+            crate::actions::register(sock, &req.environment).await?;
             true
         }
         rbw::protocol::Action::Login => {
-            crate::actions::login(sock, state.clone(), req.tty.as_deref())
+            crate::actions::login(sock, state.clone(), &req.environment)
                 .await?;
             true
         }
         rbw::protocol::Action::Unlock => {
-            crate::actions::unlock(sock, state.clone(), req.tty.as_deref())
+            crate::actions::unlock(sock, state.clone(), &req.environment)
                 .await?;
             true
         }

--- a/src/bin/rbw/actions.rs
+++ b/src/bin/rbw/actions.rs
@@ -165,10 +165,14 @@ fn wait_for_exit(pid: rustix::process::Pid) {
 }
 
 fn get_environment() -> rbw::protocol::Environment {
-    let tty = rustix::termios::ttyname(std::io::stdin(), vec![])
-        .ok()
-        .and_then(|p| p.to_str().map(String::from).ok());
     let mut env_vars = HashMap::new();
+
+    let tty = std::env::var("RBW_TTY").ok().or_else(|| {
+        rustix::termios::ttyname(std::io::stdin(), vec![])
+            .ok()
+            .and_then(|p| p.to_str().map(String::from).ok())
+    });
+
     for &env_var in rbw::protocol::ENVIRONMENT_VARIABLES {
         if let Ok(var) = std::env::var(env_var) {
             env_vars.insert(env_var.to_owned(), var);

--- a/src/pinentry.rs
+++ b/src/pinentry.rs
@@ -14,12 +14,12 @@ pub async fn getpin(
     let mut opts = tokio::process::Command::new(pinentry);
     opts.stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped());
-    let mut args = vec!["-o", "0"];
+    let mut args = vec!["--timeout", "0"];
     if let Some(tty) = tty {
-        args.extend(&["-T", tty]);
+        args.extend(&["--ttyname", tty]);
     }
     if !grab {
-        args.push("-g");
+        args.push("--grab");
     }
     opts.args(args);
     let mut child = opts.spawn().map_err(|source| Error::Spawn { source })?;

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 // eventually it would be nice to make this a const function so that we could
 // just get the version from a variable directly, but this is fine for now
 #[must_use]
@@ -13,8 +15,43 @@ pub fn version() -> u32 {
 
 #[derive(serde::Serialize, serde::Deserialize, Debug)]
 pub struct Request {
-    pub tty: Option<String>,
+    pub environment: Environment,
     pub action: Action,
+}
+
+// Taken from https://github.com/gpg/gnupg/blob/36dbca3e6944d13e75e96eace634e58a7d7e201d/common/session-env.c#L62-L91
+pub const ENVIRONMENT_VARIABLES: &[&str] = &[
+    // Used to set ttytype
+    "TERM",
+    // The X display
+    "DISPLAY",
+    // Xlib Authentication
+    "XAUTHORITY",
+    // Used by Xlib to select X input modules (e.g. "@im=SCIM")
+    "XMODIFIERS",
+    // For the Wayland display engine.
+    "WAYLAND_DISPLAY",
+    // Used by Qt and other non-GTK toolkits to check for X11 or Wayland
+    "XDG_SESSION_TYPE",
+    // Used by Qt to explicitly request X11 or Wayland; in particular, needed to
+    // make Qt use Wayland on GNOME
+    "QT_QPA_PLATFORM",
+    // Used by GTK to select GTK input modules (e.g. "scim-bridge")
+    "GTK_IM_MODULE",
+    // Used by GNOME 3 to talk to gcr over dbus
+    "DBUS_SESSION_BUS_ADDRESS",
+    // Used by Qt to select Qt input modules (e.g. "xim")
+    "QT_IM_MODULE",
+    // Used for communication with non-standard Pinentries
+    "PINENTRY_USER_DATA",
+    // Used to pass window information
+    "PINENTRY_GEOM_HINT",
+];
+
+#[derive(serde::Serialize, serde::Deserialize, Debug)]
+pub struct Environment {
+    pub tty: Option<String>,
+    pub env_vars: HashMap<String, String>,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Debug)]


### PR DESCRIPTION
I use `rbw` on a workstation with X.org, but also regularly connect through SSH from my laptop. This setup causes issues with the `rbw-agent`, since it is started by the first `rbw` command, and inherits the environment from there. `rbw-agent` is responsible for starting `pinentry`. If I run `rbw` first in my X session, `rbw-agent` will always start `pinentry` in the X session, even if I run `rbw` from an SSH session. Vice-versa, when first starting `rbw` from an SSH session, `rbw-agent`, and therefore `pinentry` never inherits the X session and it will always prompt through its curses UI.

I never had this issue when I was still using `pass` with GPG, even though GPG's architecture is similar to `rbw` in that the `gpg-agent` process is responsible for starting the `pinentry` process. I investigated the GPG source code to see what `gpg-agent` does differently compared to `rbw` to make `pinentry` always use the environment where `gpg` was executed.

As it turns out, GPG maintains a list of environment variables that are read from the `gpg` process and passed through `gpg-agent` to the `pinentry` process. Since `rbw` already does something similar with the TTY, I extended that functionality in this PR to add environment variables as well. In addition, GPG allows overriding the TTY through the `GPG_TTY` environment variable, so I added an `RBW_TTY` variable as well.

It's fairly hard to grok the GPG source code, since it mostly interacts with `pinentry` through libassuan (which is the protocol used by `pinentry`), so not everything is communicated through environment variables and there are multiple entry points (`gpg` is not the only process that uses `gpg-agent`). However, I am reasonably confident that I've extracted the relevant parts, and the current state of this PR should be functional. That said, I haven't tested all the different environment variables. You can try the main idea by switching between X and non-X TTYs and interacting with `rbw`. I haven't tested Wayland, so if someone has a Wayland desktop, I'd like to know if that works as expected.

Finally, I've updated `rbw-pinentry-keyring` such that the `pinentry` invocations inherit the arguments passed into the script. This should resolve the issue described in #196.
