### PR TITLE
Add --raw option to search command

### DIFF
--- a/src/bin/rbw/commands.rs
+++ b/src/bin/rbw/commands.rs
@@ -1093,10 +1093,12 @@ pub fn get(
     Ok(())
 }
 
-pub fn search(term: &str, folder: Option<&str>) -> anyhow::Result<()> {
+pub fn search(term: &str, folder: Option<&str>, raw: bool) -> anyhow::Result<()> {
     unlock()?;
 
     let db = load_db()?;
+
+    let mut json_entries = vec![];
 
     let found_entries: Vec<_> = db
         .entries
@@ -1106,18 +1108,23 @@ pub fn search(term: &str, folder: Option<&str>) -> anyhow::Result<()> {
             entry
                 .map(|decrypted| {
                     if decrypted.search_match(term, folder) {
-                        let mut display = decrypted.name;
-                        if let DecryptedData::Login {
-                            username: Some(username),
-                            ..
-                        } = decrypted.data
-                        {
-                            display = format!("{username}@{display}");
+                        if raw {
+                            json_entries.push(decrypted);
+                            None
+                        } else {
+                            let mut display = decrypted.name;
+                            if let DecryptedData::Login {
+                                username: Some(username),
+                                ..
+                            } = decrypted.data
+                            {
+                                display = format!("{username}@{display}");
+                            }
+                            if let Some(folder) = decrypted.folder {
+                                display = format!("{folder}/{display}");
+                            }
+                            Some(display)
                         }
-                        if let Some(folder) = decrypted.folder {
-                            display = format!("{folder}/{display}");
-                        }
-                        Some(display)
                     } else {
                         None
                     }
@@ -1126,8 +1133,13 @@ pub fn search(term: &str, folder: Option<&str>) -> anyhow::Result<()> {
         })
         .collect::<Result<_, anyhow::Error>>()?;
 
-    for name in found_entries {
-        println!("{name}");
+    if raw {
+        let j = serde_json::to_string(&json_entries)?;
+        println!("{}",j);
+    } else {
+        for name in found_entries {
+            println!("{name}");
+        }
     }
 
     Ok(())

--- a/src/bin/rbw/main.rs
+++ b/src/bin/rbw/main.rs
@@ -82,6 +82,8 @@ enum Opt {
         term: String,
         #[arg(long, help = "Folder name to search in")]
         folder: Option<String>,
+        #[structopt(long, help = "Display output as JSON")]
+	raw: bool,
     },
 
     #[command(
@@ -352,8 +354,8 @@ fn main() {
             false,
             *ignorecase,
         ),
-        Opt::Search { term, folder } => {
-            commands::search(term, folder.as_deref())
+        Opt::Search { term, folder, raw } => {
+            commands::search(term, folder.as_deref(), *raw)
         }
         Opt::Code {
             needle,


### PR DESCRIPTION
As referenced in issue #230 this adds a `--raw` to `search` to dump the raw JSON results of a search.

eg

```
% rbw search --raw nosuchentry
[]

% rbw search --raw test | jq .
[
  {
    "id": "0315e272-b3d8-4dfa-a418-2b88a8599a96",
    "folder": null,
    "name": "Test",
    "data": {
      "username": "test1",
      "password": "test",
      "totp": null,
      "uris": []
    },
    "fields": [],
    "notes": null,
    "history": []
  },
  {
    "id": "44ef6aae-b088-4fef-a0fa-0ef9586a21f3",
    "folder": null,
    "name": "Test",
    "data": {
      "cardholder_name": "test",
      "number": "12345",
      "brand": null,
      "exp_month": null,
      "exp_year": null,
      "code": null
    },
    "fields": [],
    "notes": null,
    "history": []
  }
]
```