### PR TITLE
Add rust-version metadata to declare MSRV

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "rbw"
 version = "1.13.2"
 authors = ["Jesse Luehrs <doy@tozt.net>"]
 edition = "2021"
+rust-version = "1.80.0"
 
 description = "Unofficial Bitwarden CLI"
 repository = "https://git.tozt.net/rbw"


### PR DESCRIPTION
`rbw` uzes `LazyLock` which is only stabilized in 1.80.0

e.g. when building on RHEL 9 or derivatives (which currently has 1.79.0 - it will be refreshed in the next RHEL minor release)

https://koji.fedoraproject.org/koji/taskinfo?taskID=129121049

```
error[E0658]: use of unstable library feature 'lazy_cell'
  --> src/protocol.rs:70:5
   |
70 | > = std::sync::LazyLock::new(|| {
   |     ^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: see issue #109736 <https://github.com/rust-lang/rust/issues/109736> for more information
   = help: add `#![feature(lazy_cell)]` to the crate attributes to enable
   = note: this compiler was built on 2024-06-10; consider upgrading it if it is out of date
```

see https://doc.rust-lang.org/std/sync/struct.LazyLock.html for the version it's stabilized