### PR TITLE
Update git credential helper script to support path filtering

### DIFF
--- a/bin/git-credential-rbw
+++ b/bin/git-credential-rbw
@@ -11,12 +11,15 @@ while read -r line; do
 			host=${line#*=} ;;
 		username=*)
 			user=${line#*=} ;;
+		path=*)
+			path=${line#*=} ;;
 	esac
 done
 
 output=
 #shellcheck disable=2154
 for arg in \
+	"${protocol:+$protocol://}$host/$path" \
 	"${protocol:+$protocol://}$host" \
 	"$host" \
 	"${host2=${host%.*}}" \

--- a/bin/git-credential-rbw
+++ b/bin/git-credential-rbw
@@ -19,8 +19,7 @@ done
 output=
 #shellcheck disable=2154
 for arg in \
-	"${protocol:+$protocol://}$host/$path" \
-	"${protocol:+$protocol://}$host" \
+	"${protocol:+$protocol://}$host${path:+/$path}" \
 	"$host" \
 	"${host2=${host%.*}}" \
 	"${host2#*.}"


### PR DESCRIPTION
This allows users who use git's `credential.useHttpPath` setting to filter more specifically than by host alone when pulling credentials.

In my case, I have several credentials for `[username]@gitlab.com` depending on what path is being contributed to.