### PR TITLE
Add bash+zsh completions for `rbw get` and `rbw get --folder`

### DIFF
--- a/src/bin/rbw/main-bash.sh
+++ b/src/bin/rbw/main-bash.sh
@@ -1,0 +1,55 @@
+_rbw_wrapper() {
+  local cur prev folder opts res
+  COMPREPLY=()
+
+  if [[ "${COMP_WORDS[1]}" == "get" ]]; then
+
+    # rbw get
+
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    for (( i=1; i < ${#COMP_WORDS[@]}; i++ )); do
+      if [[ "${COMP_WORDS[i-2]}" == "--folder" ]] && [[ "${COMP_WORDS[i-1]}" == "=" ]]; then
+        folder="${COMP_WORDS[i]}"
+        if [[ $i -eq $(( COMP_CWORD - 1 )) ]]; then
+          prev="--folder"
+        fi
+      elif [[ "${COMP_WORDS[i-1]}" == "--folder" ]] && [[ "${COMP_WORDS[i]}" == "=" ]]; then
+        folder=""
+        if [[ $i -eq $(( COMP_CWORD - 1 )) ]]; then
+          prev="--folder"
+          cur=""
+        fi
+      elif [[ "${COMP_WORDS[i-1]}" == "--folder" ]]; then
+        folder="${COMP_WORDS[i]}"
+      fi
+    done
+
+    if [[ "$prev" == --folder ]]; then
+      # rbw get --folder $folder
+      res=$(
+        rbw list --fields folder 2>/dev/null \
+          | awk -v folder="$folder" 'NF && $1 ~ folder {print $1}'
+      )
+
+      # Split output into an array (one entry per line)
+    elif [[ "$prev" != ^-- ]]; then
+      # rbw get ... $cur
+      res=$(
+        rbw list --fields name,folder 2>/dev/null \
+          | awk -F'\t' -v name="$cur" -v folder="$folder" '$1 ~ name && $1 && $2 ~ folder {print $1}'
+      )
+    else
+      return 0
+    fi
+
+    mapfile -t opts <<< "$res"
+    COMPREPLY=( $(compgen -W "${opts[*]}" -- "$cur") )
+    return 0
+  else
+    return 0
+  fi
+}
+
+complete -F _rbw_wrapper rbw

--- a/src/bin/rbw/main-zsh.sh
+++ b/src/bin/rbw/main-zsh.sh
@@ -1,13 +1,18 @@
 _rbw_wrapper() {
   local -a opts
-  local folder cur res
+  local cur prev folder res
 
   if [[ "${words[2]}" == "get" ]]; then
 
     # rbw get
 
     for (( i=1; i < ${#words}; i++ )); do
-      if [[ "${words[$(( i - 1 ))]}" == "--folder" ]]; then
+      cur="${words[$i]}"
+      if [[ "$cur" == --folder=* ]]; then
+        # rbw get ... --folder $folder
+        folder="${cur#--folder=}"
+        folder="${(Q)folder}"
+      elif [[ "${words[$(( i - 1 ))]}" == --folder ]]; then
         # rbw get ... --folder $folder
         folder="${(Q)words[$i]}"
         prefix=""

--- a/src/bin/rbw/main-zsh.sh
+++ b/src/bin/rbw/main-zsh.sh
@@ -1,6 +1,6 @@
 _rbw_wrapper() {
   local -a opts
-  local folder cur
+  local folder cur res
 
   if [[ "${words[2]}" == "get" ]]; then
 
@@ -10,35 +10,46 @@ _rbw_wrapper() {
       if [[ "${words[$(( i - 1 ))]}" == "--folder" ]]; then
         # rbw get ... --folder $folder
         folder="${(Q)words[$i]}"
+        prefix=""
       fi
     done
 
     local cur="${(Q)words[CURRENT]}"
 
-    if [[ "${words[-2]}" == "--folder" ]]; then
-      [[ "$folder" != "$cur" ]] || return
-      # rbw get --folder $cur
-      local res=$(
+    if [[ "$cur" == "--folder"* ]]; then
+      # rbw get --folder=$folder
+      if [[ "$cur" != "--folder" ]]; then
+        folder="${cur#--folder=}"
+        folder="${(Q)folder}"
+      fi
+      res=$(
         rbw list --fields folder \
-        | awk -v folder="$cur" "NF && /$1/ {print}"
+          | awk -v folder="$folder" 'NF && $1 ~ folder {print "--folder=" $1}'
+         )
+    elif [[ "${words[-2]}" == "--folder" ]]; then
+      # rbw get --folder $folder
+      res=$(
+        rbw list --fields folder \
+          | awk -v folder="$folder" 'NF && $1 ~ folder {print $1}'
       )
-      opts=("${(@f)${res}}")
     elif [[ "${words[-2]}" != "^--" ]]; then
       # rbw get ... $cur
-      local res=$(
+      res=$(
         rbw list --fields name,folder \
         | awk -F'\t' -v name="$cur" -v folder="$folder" '$1 ~ name && $1 && $2 ~ folder {print $1}'
       )
-      opts=("${(@f)${res}}")
     else
       _rbw
       return
     fi
 
+    opts=("${(@f)${res}}")
     compadd -S '' -- "${opts[@]}"
   else
     _rbw
   fi
+
+
 }
 
 compdef _rbw_wrapper rbw

--- a/src/bin/rbw/main-zsh.sh
+++ b/src/bin/rbw/main-zsh.sh
@@ -31,13 +31,13 @@ _rbw_wrapper() {
         rbw list --fields folder \
           | awk -v folder="$folder" 'NF && $1 ~ folder {print "--folder=" $1}'
          )
-    elif [[ "${words[-2]}" == "--folder" ]]; then
+    elif [[ "$prev" == "--folder" ]]; then
       # rbw get --folder $folder
       res=$(
         rbw list --fields folder \
           | awk -v folder="$folder" 'NF && $1 ~ folder {print $1}'
       )
-    elif [[ "${words[-2]}" != "^--" ]]; then
+    elif [[ "$prev" != -* ]] && [[ "$cur" != -* ]]; then
       # rbw get ... $cur
       res=$(
         rbw list --fields name,folder \
@@ -48,12 +48,15 @@ _rbw_wrapper() {
       return
     fi
 
-    opts=("${(@f)${res}}")
-    compadd -S '' -- "${opts[@]}"
+    if [[ "$res" == "$cur" ]]; then
+      compadd -S '' -- "${opts[@]}"
+    else
+      opts=("${(@f)${res}}")
+      compadd -S '' -- "${opts[@]}"
+    fi
   else
     _rbw
   fi
-
 
 }
 

--- a/src/bin/rbw/main.rs
+++ b/src/bin/rbw/main.rs
@@ -468,6 +468,9 @@ fn main() {
             if *shell == clap_complete::Shell::Zsh {
                 println!("{}", include_str!("main-zsh.sh"));
             }
+            if *shell == clap_complete::Shell::Bash {
+                println!("{}", include_str!("main-bash.sh"));
+            }
             Ok(())
         }
     }

--- a/src/bin/rbw/main.rs
+++ b/src/bin/rbw/main.rs
@@ -466,7 +466,7 @@ fn main() {
                 &mut std::io::stdout(),
             );
             if *shell == clap_complete::Shell::Zsh {
-                println!("{}", include_str!("main.zsh"));
+                println!("{}", include_str!("main-zsh.sh"));
             }
             Ok(())
         }

--- a/src/bin/rbw/main.rs
+++ b/src/bin/rbw/main.rs
@@ -465,6 +465,9 @@ fn main() {
                 "rbw",
                 &mut std::io::stdout(),
             );
+            if *shell == clap_complete::Shell::Zsh {
+                println!("{}", include_str!("main.zsh"));
+            }
             Ok(())
         }
     }

--- a/src/bin/rbw/main.zsh
+++ b/src/bin/rbw/main.zsh
@@ -1,0 +1,44 @@
+_rbw_wrapper() {
+  local -a opts
+  local folder cur
+
+  if [[ "${words[2]}" == "get" ]]; then
+
+    # rbw get
+
+    for (( i=1; i < ${#words}; i++ )); do
+      if [[ "${words[$(( i - 1 ))]}" == "--folder" ]]; then
+        # rbw get ... --folder $folder
+        folder="${(Q)words[$i]}"
+      fi
+    done
+
+    local cur="${(Q)words[CURRENT]}"
+
+    if [[ "${words[-2]}" == "--folder" ]]; then
+      [[ "$folder" != "$cur" ]] || return
+      # rbw get --folder $cur
+      local res=$(
+        rbw list --fields folder \
+        | awk -v folder="$cur" "NF && /$1/ {print}"
+      )
+      opts=("${(@f)${res}}")
+    elif [[ "${words[-2]}" != "^--" ]]; then
+      # rbw get ... $cur
+      local res=$(
+        rbw list --fields name,folder \
+        | awk -F'\t' -v name="$cur" -v folder="$folder" '$1 ~ name && $1 && $2 ~ folder {print $1}'
+      )
+      opts=("${(@f)${res}}")
+    else
+      _rbw
+      return
+    fi
+
+    compadd -S '' -- "${opts[@]}"
+  else
+    _rbw
+  fi
+}
+
+compdef _rbw_wrapper rbw


### PR DESCRIPTION
I'm not a rust programmer, so I just wrapped your autogenerated _rbw in a bash/zsh script that adds completions to bash/zsh for folders and item names using awk. Its a usable hack, so feel free to use it as a starting point if you like it.

If someone is willing to implement options to `rbw list` that filter by folder or item name, then this can replace the usage of awk. To integrate dynamic completions into clap-generated output I append the main-bash.sh and main-zsh.sh scripts at compile time, which wrap the static completions given by _rbw.