### PR TITLE
rbw commands: optionally disable agent start

### DIFF
--- a/src/bin/rbw/commands.rs
+++ b/src/bin/rbw/commands.rs
@@ -1617,6 +1617,11 @@ fn ensure_agent_once() -> anyhow::Result<()> {
     let agent_path = agent_path
         .as_deref()
         .unwrap_or_else(|| std::ffi::OsStr::from_bytes(b"rbw-agent"));
+
+    if agent_path == "OFF" {
+        return Ok(());
+    }
+
     let status = std::process::Command::new(agent_path)
         .status()
         .context("failed to run rbw-agent")?;


### PR DESCRIPTION
Gives the possibility to disable the implicit launch of rbw-agent by setting RBW_AGENT=OFF. Useful when starting rbw-agent explicitly for debugging.