### PR TITLE
Swap toml_lite for toml_rs and add Steam TOTP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 /pkg
 /target
 /target-ra

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,6 +415,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
 name = "core-foundation"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1128,7 +1134,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1728,7 +1734,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-tungstenite",
- "totp-lite",
+ "totp-rs",
  "url",
  "urlencoding",
  "uuid",
@@ -2407,12 +2413,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "totp-lite"
-version = "2.0.1"
+name = "totp-rs"
+version = "5.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8e43134db17199f7f721803383ac5854edd0d3d523cc34dba321d6acfbe76c3"
+checksum = "f124352108f58ef88299e909f6e9470f1cdc8d2a1397963901b4a6366206bf72"
 dependencies = [
- "digest",
+ "base32",
+ "constant_time_eq",
  "hmac",
  "sha1",
  "sha2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ thiserror = "1.0.63"
 tokio-stream = { version = "0.1.17", features = ["net"] }
 tokio-tungstenite = { version = "0.24", features = ["rustls-tls-native-roots", "url"] }
 tokio = { version = "1.42.0", features = ["full"] }
-totp-lite = "2.0.1"
+totp-rs = {  version = "5.7.0", features = [ "steam" ] }
 url = "2.5.4"
 urlencoding = "2.1.3"
 uuid = { version = "1.11.0", features = ["v4"] }


### PR DESCRIPTION
This was discussed privately before (about the TOTP library change), but all I wanted is to have Steam TOTP auth key support which this merge request adds.

Only caveat I ran into is that this new library (totp-rs) does not like TOTP keys shorter than 6 or longer than 8 characters, so if that is an issue, please notify me before merging. Though in normal circumstances I did not run into this in the wild so I *assumed* that it isn't an issue.

In other cases, tested both Steam TOTP and normal TOTP and they both seem to work after these changes, so it should be mergable right away.

PS: Sorry for the 5 month delay :| (kinda slacked off on making this)