### PR TITLE
Fix Clippy warnings for code quality compliance

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -770,7 +770,7 @@ pub struct Client {
     base_url: String,
     identity_url: String,
     ui_url: String,
-    client_cert_path: Option<std::path::PathBuf>,
+    cert_path: Option<std::path::PathBuf>,
 }
 
 impl Client {
@@ -778,14 +778,13 @@ impl Client {
         base_url: &str,
         identity_url: &str,
         ui_url: &str,
-        client_cert_path: Option<&std::path::Path>,
+        cert_path: Option<&std::path::Path>,
     ) -> Self {
         Self {
             base_url: base_url.to_string(),
             identity_url: identity_url.to_string(),
             ui_url: ui_url.to_string(),
-            client_cert_path: client_cert_path
-                .map(std::path::Path::to_path_buf),
+            cert_path: cert_path.map(std::path::Path::to_path_buf),
         }
     }
 
@@ -811,18 +810,19 @@ impl Client {
             env!("CARGO_PKG_NAME"),
             env!("CARGO_PKG_VERSION")
         );
-        if let Some(client_cert_path) = self.client_cert_path.as_ref() {
+        if let Some(cert_path) = self.cert_path.as_ref() {
             let mut buf = Vec::new();
-            let mut f = tokio::fs::File::open(client_cert_path)
-                .await
-                .map_err(|e| Error::LoadClientCert {
-                    source: e,
-                    file: client_cert_path.clone(),
+            let mut f =
+                tokio::fs::File::open(cert_path).await.map_err(|e| {
+                    Error::LoadClientCert {
+                        source: e,
+                        file: cert_path.clone(),
+                    }
                 })?;
             f.read_to_end(&mut buf).await.map_err(|e| {
                 Error::LoadClientCert {
                     source: e,
-                    file: client_cert_path.clone(),
+                    file: cert_path.clone(),
                 }
             })?;
             let pem = reqwest::Identity::from_pem(&buf)

--- a/src/api.rs
+++ b/src/api.rs
@@ -62,10 +62,12 @@ pub enum TwoFactorProviderType {
 impl TwoFactorProviderType {
     pub fn message(&self) -> &str {
         match *self {
-            Self::Authenticator => "Enter the 6 digit verification code from your authenticator app.",
+            Self::Authenticator => {
+                "Enter the 6 digit verification code from your authenticator app."
+            }
             Self::Yubikey => "Insert your Yubikey and push the button.",
             Self::Email => "Enter the PIN you received via email.",
-            _ => "Enter the code."
+            _ => "Enter the code.",
         }
     }
 
@@ -1615,7 +1617,9 @@ fn sso_query_code(
 
     if received_state.split("_identifier=").next().unwrap() != state {
         return Err(Error::FailedToProcessSSOCallback {
-            msg: format!("SSO callback states do not match, sent: {state}, received: {received_state}"),
+            msg: format!(
+                "SSO callback states do not match, sent: {state}, received: {received_state}"
+            ),
         });
     }
 

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -23,7 +23,7 @@ impl Identity {
             .ok_or(Error::Pbkdf2ZeroIterations)?;
 
         let mut keys = crate::locked::Vec::new();
-        keys.extend(std::iter::repeat_n(0, 64));
+        keys.extend(std::iter::repeat(0).take(64));
 
         let enc_key = &mut keys.data_mut()[0..32];
 
@@ -65,7 +65,7 @@ impl Identity {
         }
 
         let mut hash = crate::locked::Vec::new();
-        hash.extend(std::iter::repeat_n(0, 32));
+        hash.extend(std::iter::repeat(0).take(32));
         pbkdf2::pbkdf2::<hmac::Hmac<sha2::Sha256>>(
             enc_key,
             password.password(),

--- a/src/locked.rs
+++ b/src/locked.rs
@@ -50,7 +50,7 @@ impl Vec {
 
     pub fn zero(&mut self) {
         self.truncate(0);
-        self.data.extend(std::iter::repeat_n(0, LEN));
+        self.data.extend(std::iter::repeat(0).take(LEN));
     }
 
     pub fn extend(&mut self, it: impl Iterator<Item = u8>) {


### PR DESCRIPTION
### Summary
Resolved multiple Clippy warnings to ensure CI pipeline passes and maintain code quality standards.

### Problem
CI was failing due to Clippy warnings that violated the code quality checks, preventing successful builds and deployments.

### Changes
- **MSRV Compatibility**: Replaced `std::iter::repeat_n()` with `std::iter::repeat().take()` in `src/identity.rs` and `src/locked.rs` to maintain compatibility with Rust 1.80.0
- **Naming Conventions**: Renamed field to follow Rust naming conventions and avoid redundant prefixes in `src/api.rs`
- **Code Formatting**: Applied `cargo fmt` to `src/api.rs` for consistent code style

### Testing
- [x] Code compiles successfully with MSRV 1.80.0
- [x] All existing tests continue to pass

### Files Modified
- `src/identity.rs`
- `src/locked.rs` 
- `src/api.rs`

All changes maintain identical functionality while improving code quality and ensuring CI compliance.