### PR TITLE
docs: add fuzzel-rbw

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ the instructions [here](https://bitwarden.com/help/article/personal-api-key/).
 ## Related projects
 
 * [rofi-rbw](https://github.com/fdw/rofi-rbw): A rofi frontend for Bitwarden
+* [fuzzel-rbw](https://github.com/sammhansen/fuzzel-rbw): A fuzzel frontend for Bitwarden
 * [bw-ssh](https://framagit.org/Glandos/bw-ssh/): Manage SSH key passphrases in Bitwarden
 * [rbw-menu](https://github.com/rbuchberger/rbw-menu): Tiny menu picker for rbw
 * [ulauncher-rbw](https://0xacab.org/varac-projects/ulauncher-rbw): [Ulauncher](https://ulauncher.io/) rbw extension


### PR DESCRIPTION
- **docs**
   - add  link to fuzzel-rbw: a fuzzel frontend for bitwarden