### PR TITLE
fix: `TOTP::new` changed to `TOTP::new_unchecked`

### DIFF
--- a/src/bin/rbw/commands.rs
+++ b/src/bin/rbw/commands.rs
@@ -2437,13 +2437,13 @@ fn generate_totp(secret: &str) -> anyhow::Result<String> {
     let alg = totp_params.algorithm.as_str();
 
     match alg {
-        "SHA1" | "SHA256" | "SHA512" => Ok(totp_rs::TOTP::new(
+        "SHA1" | "SHA256" | "SHA512" => Ok(totp_rs::TOTP::new_unchecked(
             generate_totp_algorithm_type(alg)?,
             totp_params.digits,
             1, // the library docs say this should be a 1
             totp_params.period,
             totp_params.secret,
-        )?
+        )
         .generate_current()?),
         "STEAM" => Ok(totp_rs::TOTP::new_steam(totp_params.secret)
             .generate_current()?),


### PR DESCRIPTION
This prevents errors such as `The length of the shared secret MUST be at least 128 bits. 80 bits is not enough` (#269)