### PR TITLE
Avoid loading fields that would trigger master password prompt duing `get` and `search`

### DIFF
--- a/src/bin/rbw-agent/agent.rs
+++ b/src/bin/rbw-agent/agent.rs
@@ -147,6 +147,7 @@ async fn handle_request(
             cipherstring,
             entry_key,
             org_id,
+            skip_protected,
         } => {
             let cipherstring = cipherstring.clone();
             let entry_key = entry_key.clone();
@@ -158,6 +159,7 @@ async fn handle_request(
                 &cipherstring,
                 entry_key.as_deref(),
                 org_id.as_deref(),
+                *skip_protected,
             )
             .await?;
             true

--- a/src/bin/rbw/commands.rs
+++ b/src/bin/rbw/commands.rs
@@ -1190,7 +1190,7 @@ pub fn search(
     let mut entries: Vec<DecryptedListCipher> = db
         .entries
         .iter()
-        .map(decrypt_search_cipher)
+        .map(|entry| decrypt_search_cipher(entry, true))
         .filter(|entry| {
             entry
                 .as_ref()
@@ -1721,7 +1721,7 @@ fn find_entry(
         .entries
         .iter()
         .map(|entry| {
-            decrypt_search_cipher(entry)
+            decrypt_search_cipher(entry, false)
                 .map(|decrypted| (entry.clone(), decrypted))
         })
         .collect::<anyhow::Result<_>>()?;
@@ -1862,6 +1862,7 @@ fn decrypt_list_cipher(
 
 fn decrypt_search_cipher(
     entry: &rbw::db::Entry,
+    load_fields: bool,
 ) -> anyhow::Result<DecryptedSearchCipher> {
     let id = entry.id.clone();
     let name = crate::actions::decrypt(
@@ -1911,7 +1912,8 @@ fn decrypt_search_cipher(
     } else {
         vec![]
     };
-    let fields = entry
+    let fields = if load_fields {
+        entry
         .fields
         .iter()
         .filter_map(|field| field.value.as_ref())
@@ -1922,7 +1924,10 @@ fn decrypt_search_cipher(
                 entry.org_id.as_deref(),
             )
         })
-        .collect::<anyhow::Result<_>>()?;
+        .collect::<anyhow::Result<_>>()?
+    } else {
+        vec![]
+    };
     let notes = match notes {
         Ok(notes) => notes,
         Err(e) => {

--- a/src/bin/rbw/main.rs
+++ b/src/bin/rbw/main.rs
@@ -90,6 +90,13 @@ enum Opt {
         term: String,
         #[arg(
             long,
+            default_value = "false",
+            help = "Search within master-password protected fields. \
+                Note that this might cause multiple master-password reprompts."
+        )]
+        include_protected_fields: bool,
+        #[arg(
+            long,
             help = "Fields to display. \
                 Available options are id, name, user, folder. \
                 Multiple fields will be separated by tabs.",
@@ -358,10 +365,17 @@ fn main() {
         ),
         Opt::Search {
             term,
+            include_protected_fields,
             fields,
             folder,
             raw,
-        } => commands::search(&term, &fields, folder.as_deref(), raw),
+        } => commands::search(
+            &term,
+            include_protected_fields,
+            &fields,
+            folder.as_deref(),
+            raw,
+        ),
         Opt::Code {
             find_args,
             #[cfg(feature = "clipboard")]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -173,6 +173,7 @@ pub enum Action {
         cipherstring: String,
         entry_key: Option<String>,
         org_id: Option<String>,
+        skip_protected: bool,
     },
     Encrypt {
         plaintext: String,
@@ -193,4 +194,5 @@ pub enum Response {
     Decrypt { plaintext: String },
     Encrypt { cipherstring: String },
     Version { version: u32 },
+    CipertextIsProtected,
 }


### PR DESCRIPTION
An attempt to resolve https://github.com/doy/rbw/issues/268#issuecomment-3247198361

Avoid loading fields that would force a master password reprompt in search

We introduce a new field, `skip_protected` in the `decrypt` request
to the agent. The agent would simply reply with `CipherIsProtected` when asked
to decrypt a cipher that would otherwise force a master password reprompt.

The client would by default bypass all such fields during `get` and `search`
(note that the reprompt would still happen as part of fetching the fields for _displaying_);
unless prompted with `--include-protected-fields`, in which the old behavior will occur
as before.

**Note**: The first commit to this PR is a much more lightweight implementation that
simply ignores all fields during `get`, which would resolve the comment already, but still
will trigger the unwanted behavior for `search`. I'm not sure which one is preferred, but
in the case of merging both I would prefer to simply drop the first commit or merge as squashed,
since the 2nd commit would completely make the 1st one obsolete.
