### PR TITLE
README: provides 2FA information (#292)

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,21 @@ export SSH_AUTH_SOCK="$XDG_RUNTIME_DIR/rbw/ssh-agent-socket"
 If you're using a profile, the socket will be located at
 `"XDG_RUNTIME_DIR/rbw-<profile>/ssh-agent-socket"`.
 
+### 2FA support
+
+`rbw` supports the following 2FA mechanisms :
+
+* Email
+* Authenticator App
+* Yubico OTP security key (https://support.yubico.com/hc/en-us/articles/360013712639-Testing-Yubico-OTP)
+
+WebAuthn / Passkey and Duo security are unsupported 2FA mechanisms.
+
+If you use only unsupported 2FA mechanism, you need to add a supported 2FA
+mechanism on your bitwarden account to use rbw. It allows you to use rbw
+with a supported mechanism, and use other clients with you preferred
+2FA mechanism.
+
 ## Related projects
 
 * [rofi-rbw](https://github.com/fdw/rofi-rbw): A rofi frontend for Bitwarden


### PR DESCRIPTION
As 2FA is a common way to secure connection, it may be a big help to provide some information about 2FA (what is supported, what is not, what are the possible setup).

See the linked issue about the original user feedback.