### PR TITLE
docs: add Debian official package information

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,11 @@ will always build from the latest master commit.
 
 ### Debian/Ubuntu
 
-You can download a Debian package from
+`rbw` is officially packaged for Debian as
+[`rust-rbw`](https://tracker.debian.org/pkg/rust-rbw) and is available in
+testing (forky). You can install it using `sudo apt install rbw`.
+
+Alternatively, you can download a Debian package from
 [https://git.tozt.net/rbw/releases/deb/
 ](https://git.tozt.net/rbw/releases/deb/). The packages are signed by
 [`minisign`](https://github.com/jedisct1/minisign), and can be verified using


### PR DESCRIPTION
Update README to indicate that rbw is officially packaged for Debian as `rust-rbw` and is available in testing (forky). Added installation instructions using apt, while keeping the manual download option as an alternative.