### PR TITLE
feat: don't truncate ssh key comments

### DIFF
--- a/src/bin/rbw-agent/ssh_agent.rs
+++ b/src/bin/rbw-agent/ssh_agent.rs
@@ -43,7 +43,11 @@ impl ssh_agent_lib::agent::Session for SshAgent {
                 p.parse::<ssh_agent_lib::ssh_key::PublicKey>()
                     .map(|pk| ssh_agent_lib::proto::Identity {
                         pubkey: pk.key_data().clone(),
-                        comment: p.splitn(3, ' ').nth(2).unwrap_or("").to_string(),
+                        comment: p
+                            .splitn(3, ' ')
+                            .nth(2)
+                            .unwrap_or("")
+                            .to_string(),
                     })
                     .map_err(ssh_agent_lib::error::AgentError::other)
             })

--- a/src/bin/rbw-agent/ssh_agent.rs
+++ b/src/bin/rbw-agent/ssh_agent.rs
@@ -43,7 +43,7 @@ impl ssh_agent_lib::agent::Session for SshAgent {
                 p.parse::<ssh_agent_lib::ssh_key::PublicKey>()
                     .map(|pk| ssh_agent_lib::proto::Identity {
                         pubkey: pk.key_data().clone(),
-                        comment: String::new(),
+                        comment: p.splitn(3, ' ').nth(2).unwrap_or("").to_string(),
                     })
                     .map_err(ssh_agent_lib::error::AgentError::other)
             })


### PR DESCRIPTION
When using the rbw ssh-agent, it would omit the comments for the ssh keys.

For someone with more than one ssh-key, this might lead to circumstances in which it is unclear if the correct keys are present in the agent.

This PR solves this, by including the comments set in the ssh keys, so they are rendered correctly by `ssh-add -L`.