### PR TITLE
chore: patch for `RUSTSEC-2026-0007` and `RUSTSEC-2026-0049` 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,9 +266,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cbc"
@@ -2147,9 +2147,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.8"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
### What changed:

Updated Cargo.lock only:
- bytes 1.11.0 → 1.11.1
- rustls-webpki 0.103.8 → 0.103.10

### Why:

These are the exact patched versions recommended by the reported advisories:
- RUSTSEC-2026-0007
- RUSTSEC-2026-0049

### Validation:

```
cargo fmt --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all-features
cargo deny check
```

All passed, cargo deny check now reports: advisories ok, bans ok, licenses ok, sources ok

Agent-Logs-Url: https://github.com/smallstepman/rbw/sessions/c1a926dd-380e-4b90-ae9a-99bf86eba411