### PR TITLE
Add rbw edit --field to update custom fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,10 @@
   vault to disk before replacing that in-memory set; a refresh
   failure after a successful PUT is an error (`rbw sync`), not a
   silent success. Stale-cipher responses (HTTP 400 "out of date" or
-  409) map to a retryable conflict error.
+  409) map to a retryable conflict error. Field conflict retries
+  compare the target field's plaintext: official clients re-encrypt
+  every custom field on save, so a notes-only edit changes ciphertext
+  without changing the value.
 * A rejected *editor* edit keeps the plaintext in `$RBW
   runtime/unsaved-edits/` (directory mode 0700, files 0600,
   `O_EXCL`) until you delete it. Piped stdin is not written to disk.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,11 @@
 * Cipher PUT now sends `reprompt`, `favorite`, `archivedDate`, and
   `lastKnownRevisionDate`. `rbw edit` syncs before resolving the
   name/URI selector, and again after a successful PUT so the agent
-  rebuilds its master-password-reprompt set. Stale-cipher responses
-  (HTTP 400 "out of date" or 409) map to a retryable conflict error.
+  rebuilds its master-password-reprompt set. A failed cache refresh
+  after a successful PUT is a warning, not an edit failure.
+  Stale-cipher responses (HTTP 400 "out of date" or 409) map to a
+  retryable conflict error. Rejected edits keep the plaintext in
+  `$RBW runtime/unsaved-edits/` (mode 0600) until you delete it.
 
 ## [1.15.0] - 2025-12-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,8 +35,10 @@
   rebuilds its master-password-reprompt set. The agent writes the
   vault to disk before replacing that in-memory set; a refresh
   failure after a successful PUT is an error (`rbw sync`), not a
-  silent success. `rbw add`, `rbw edit`, and `rbw generate` then exit
-  2 (not 1) and tell you not to retry the write. Stale-cipher
+  silent success. After the server write, any local follow-up failure
+  (token save, cache refresh, reload) makes `rbw add`, `rbw edit`, and
+  `rbw generate` exit 2 (not 1) and tells you not to retry the write.
+  Stale-cipher
   responses (HTTP 400 "out of date" or 409) map to a retryable
   conflict error. Field conflict retries compare the target field's
   plaintext: official clients re-encrypt every custom field on save,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,10 @@
   and preserves `key` on the cipher PUT, so keyed items are not corrupted
   (#364, #368).
 * Cipher PUT now sends `reprompt`, `favorite`, `archivedDate`, and
-  `lastKnownRevisionDate`. Edits sync first so a stale cache cannot
-  overwrite another client's password or notes, or unfavorite an item
-  on the first edit after upgrade.
+  `lastKnownRevisionDate`. `rbw edit` syncs once before resolving the
+  name/URI selector, then writes the local snapshot after PUT (no
+  second full sync). Stale-cipher responses (HTTP 400 "out of date" or
+  409) map to a retryable conflict error.
 
 ## [1.15.0] - 2025-12-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,10 @@
 * `rbw edit` encrypts with the entry's individual item key when present
   and preserves `key` on the cipher PUT, so keyed items are not corrupted
   (#364, #368).
-* Cipher PUT now sends `reprompt`, `favorite`, and `archivedDate` from
-  the last sync so a field-only edit does not reset them.
+* Cipher PUT now sends `reprompt`, `favorite`, `archivedDate`, and
+  `lastKnownRevisionDate`. Edits sync first so a stale cache cannot
+  overwrite another client's password or notes, or unfavorite an item
+  on the first edit after upgrade.
 
 ## [1.15.0] - 2025-12-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,10 @@
   and preserves `key` on the cipher PUT, so keyed items are not corrupted
   (#364, #368).
 * Cipher PUT now sends `reprompt`, `favorite`, `archivedDate`, and
-  `lastKnownRevisionDate`. `rbw edit` syncs once before resolving the
-  name/URI selector, then writes the local snapshot after PUT (no
-  second full sync). Stale-cipher responses (HTTP 400 "out of date" or
-  409) map to a retryable conflict error.
+  `lastKnownRevisionDate`. `rbw edit` syncs before resolving the
+  name/URI selector, and again after a successful PUT so the agent
+  rebuilds its master-password-reprompt set. Stale-cipher responses
+  (HTTP 400 "out of date" or 409) map to a retryable conflict error.
 
 ## [1.15.0] - 2025-12-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,22 @@
 
 ## Added
 
-* `rbw edit --field=<name>` updates an existing custom field. Piped stdin
-  is stored as the new value; an interactive terminal opens the editor.
-  SSH key entries and linked fields are refused; boolean fields must be
-  `true` or `false`. Empty values are refused. The editor help text is
-  stripped as a suffix, not by dropping every `#` line (#370).
+* `rbw edit --field=<name>` updates an existing custom field on login,
+  secure note, card, and identity entries. Piped stdin is stored as the
+  new value; an interactive terminal opens the editor. SSH key entries
+  and linked fields are refused; boolean fields must be `true` or
+  `false`. Empty values are refused. The editor help block is removed by
+  content, not only as a suffix (#370).
+* `rbw get --list-custom-fields` lists editable custom field names
+  without decrypting hidden values (#370).
 
 ## Fixed
 
 * `rbw edit` encrypts with the entry's individual item key when present
   and preserves `key` on the cipher PUT, so keyed items are not corrupted
   (#364, #368).
+* Cipher PUT now sends `reprompt`, `favorite`, and `archivedDate` from
+  the last sync so a field-only edit does not reset them.
 
 ## [1.15.0] - 2025-12-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@
 
 * `rbw edit --field=<name>` updates an existing custom field. Piped stdin
   is stored as the new value; an interactive terminal opens the editor.
+  SSH key entries and linked fields are refused; boolean fields must be
+  `true` or `false`. The editor help text is stripped as a suffix, not by
+  dropping every `#` line.
+
+### Fixed
+
+* `rbw edit` encrypts with the entry's individual item key when present
+  and preserves `key` on the cipher PUT, so keyed items are not corrupted
+  (#364, #368).
 
 ## [1.15.0] - 2025-12-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,15 +35,17 @@
   rebuilds its master-password-reprompt set. The agent writes the
   vault to disk before replacing that in-memory set; a refresh
   failure after a successful PUT is an error (`rbw sync`), not a
-  silent success. Stale-cipher responses (HTTP 400 "out of date" or
-  409) map to a retryable conflict error. Field conflict retries
-  compare the target field's plaintext: official clients re-encrypt
-  every custom field on save, so a notes-only edit changes ciphertext
-  without changing the value.
-* A rejected *editor* edit keeps the plaintext in `$RBW
-  runtime/unsaved-edits/` (directory mode 0700, files 0600,
-  `O_EXCL`) until you delete it. Piped stdin is not written to disk.
-  `rbw purge` removes that directory.
+  silent success. `rbw add`, `rbw edit`, and `rbw generate` then exit
+  2 (not 1) and tell you not to retry the write. Stale-cipher
+  responses (HTTP 400 "out of date" or 409) map to a retryable
+  conflict error. Field conflict retries compare the target field's
+  plaintext: official clients re-encrypt every custom field on save,
+  so a notes-only edit changes ciphertext without changing the value.
+* A rejected interactive editor (`rbw add`, `rbw edit`, `rbw edit
+  --field`) keeps the plaintext in `$RBW runtime/unsaved-edits/`
+  (directory mode 0700, files 0600, `O_EXCL`) until you delete it.
+  Piped stdin is not written to disk. `rbw purge` removes that
+  directory.
 
 ## [1.15.0] - 2025-12-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@
 * `rbw get --list-custom-fields` lists editable custom field names
   without decrypting hidden values (#370).
 
+## Changed
+
+* `db::Entry` now includes `favorite`, `archived_date`, and
+  `revision_date` so a field-only PUT can round-trip those values.
+  This is a Rust source break for struct literals and exhaustive
+  matches; JSON cache load stays compatible via `serde(default)`.
+* `actions::edit` and `Client::edit` are removed. They omitted item
+  `key` and wrote `favorite=false` / `archivedDate=null`, which could
+  mix-key-corrupt keyed items and unfavorite/unarchive others. Use
+  `edit_with_meta`.
+
 ## Fixed
 
 * `rbw edit` encrypts with the entry's individual item key when present
@@ -21,11 +32,15 @@
 * Cipher PUT now sends `reprompt`, `favorite`, `archivedDate`, and
   `lastKnownRevisionDate`. `rbw edit` syncs before resolving the
   name/URI selector, and again after a successful PUT so the agent
-  rebuilds its master-password-reprompt set. A failed cache refresh
-  after a successful PUT is a warning, not an edit failure.
-  Stale-cipher responses (HTTP 400 "out of date" or 409) map to a
-  retryable conflict error. Rejected edits keep the plaintext in
-  `$RBW runtime/unsaved-edits/` (mode 0600) until you delete it.
+  rebuilds its master-password-reprompt set. The agent writes the
+  vault to disk before replacing that in-memory set; a refresh
+  failure after a successful PUT is an error (`rbw sync`), not a
+  silent success. Stale-cipher responses (HTTP 400 "out of date" or
+  409) map to a retryable conflict error.
+* A rejected *editor* edit keeps the plaintext in `$RBW
+  runtime/unsaved-edits/` (directory mode 0700, files 0600,
+  `O_EXCL`) until you delete it. Piped stdin is not written to disk.
+  `rbw purge` removes that directory.
 
 ## [1.15.0] - 2025-12-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+* `rbw edit --field=<name>` updates an existing custom field. Piped stdin
+  is stored as the new value; an interactive terminal opens the editor.
+
 ## [1.15.0] - 2025-12-31
 
 ## Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,15 @@
 
 ## Unreleased
 
-### Added
+## Added
 
 * `rbw edit --field=<name>` updates an existing custom field. Piped stdin
   is stored as the new value; an interactive terminal opens the editor.
   SSH key entries and linked fields are refused; boolean fields must be
-  `true` or `false`. The editor help text is stripped as a suffix, not by
-  dropping every `#` line.
+  `true` or `false`. Empty values are refused. The editor help text is
+  stripped as a suffix, not by dropping every `#` line (#370).
 
-### Fixed
+## Fixed
 
 * `rbw edit` encrypts with the entry's individual item key when present
   and preserves `key` on the cipher PUT, so keyed items are not corrupted

--- a/README.md
+++ b/README.md
@@ -126,7 +126,9 @@ functionality.
 Run `rbw get <name>` to get your passwords. If you also want to get the username
 or the note associated, you can use the flag `--full`. You can also use the flag
 `--field={field}` to get whatever default or custom field you want. The `--raw`
-flag will show the output as JSON. In addition to matching against the name,
+flag will show the output as JSON. Run `rbw edit --field={field} <name>` to
+change an existing custom field: piped stdin is stored as the new value, or
+an editor is opened when stdin is a terminal. In addition to matching against the name,
 you can pass a UUID as the name to search for the entry with that id, or a
 URL to search for an entry with a matching website entry.
 

--- a/README.md
+++ b/README.md
@@ -127,13 +127,15 @@ Run `rbw get <name>` to get your passwords. If you also want to get the
 username or the note associated, you can use the flag `--full`. You can
 also use the flag `--field={field}` to get whatever default or custom
 field you want. The `--raw` flag will show the output as JSON. Run
-`rbw edit --field={field} <name>` to change an existing custom field:
-piped stdin is stored as the new value (trailing newlines are stripped),
-or an editor is opened when stdin is a terminal. Empty values are
-refused. SSH key entries and linked fields cannot be edited this way. In
-addition to matching against the name, you can pass a UUID as the name
-to search for the entry with that id, or a URL to search for an entry
-with a matching website entry.
+`rbw edit --field={field} <name>` to change an existing custom field on
+login, secure note, card, and identity entries: piped stdin is stored as
+the new value (trailing newlines are stripped), or an editor is opened
+when stdin is a terminal. Empty values are refused. SSH key entries and
+linked fields cannot be edited this way. `rbw get --list-custom-fields`
+lists the editable custom field names for an entry. In addition to
+matching against the name, you can pass a UUID as the name to search for
+the entry with that id, or a URL to search for an entry with a matching
+website entry.
 
 *Note to users of the official Bitwarden server (at bitwarden.com)*: The
 official server has a tendency to detect command line traffic as bot traffic

--- a/README.md
+++ b/README.md
@@ -128,7 +128,8 @@ or the note associated, you can use the flag `--full`. You can also use the flag
 `--field={field}` to get whatever default or custom field you want. The `--raw`
 flag will show the output as JSON. Run `rbw edit --field={field} <name>` to
 change an existing custom field: piped stdin is stored as the new value, or
-an editor is opened when stdin is a terminal. In addition to matching against the name,
+an editor is opened when stdin is a terminal. SSH key entries and linked
+fields cannot be edited this way. In addition to matching against the name,
 you can pass a UUID as the name to search for the entry with that id, or a
 URL to search for an entry with a matching website entry.
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,12 @@ vault before opening the editor, so it needs network access. Piped
 stdin is stored as the new value (trailing newlines are stripped), or an
 editor is opened when stdin is a terminal. Empty values are refused.
 SSH key entries and linked fields cannot be edited this way.
+If an interactive editor save fails before the server write, the typed
+buffer is kept under the rbw runtime `unsaved-edits/` directory; delete
+it after recovering, or run `rbw purge`. Piped stdin is never written
+there. If the server write succeeded but the local cache could not be
+refreshed, the command exits 2 — run `rbw sync` and do not retry the
+write.
 `rbw get --list-custom-fields` lists the editable custom field names for
 an entry. In addition to matching against the name, you can pass a UUID
 as the name to search for the entry with that id, or a URL to search for

--- a/README.md
+++ b/README.md
@@ -123,15 +123,17 @@ out by running `rbw purge`, and you can explicitly lock the database by running
 `rbw help` can be used to get more information about the available
 functionality.
 
-Run `rbw get <name>` to get your passwords. If you also want to get the username
-or the note associated, you can use the flag `--full`. You can also use the flag
-`--field={field}` to get whatever default or custom field you want. The `--raw`
-flag will show the output as JSON. Run `rbw edit --field={field} <name>` to
-change an existing custom field: piped stdin is stored as the new value, or
-an editor is opened when stdin is a terminal. SSH key entries and linked
-fields cannot be edited this way. In addition to matching against the name,
-you can pass a UUID as the name to search for the entry with that id, or a
-URL to search for an entry with a matching website entry.
+Run `rbw get <name>` to get your passwords. If you also want to get the
+username or the note associated, you can use the flag `--full`. You can
+also use the flag `--field={field}` to get whatever default or custom
+field you want. The `--raw` flag will show the output as JSON. Run
+`rbw edit --field={field} <name>` to change an existing custom field:
+piped stdin is stored as the new value (trailing newlines are stripped),
+or an editor is opened when stdin is a terminal. Empty values are
+refused. SSH key entries and linked fields cannot be edited this way. In
+addition to matching against the name, you can pass a UUID as the name
+to search for the entry with that id, or a URL to search for an entry
+with a matching website entry.
 
 *Note to users of the official Bitwarden server (at bitwarden.com)*: The
 official server has a tendency to detect command line traffic as bot traffic

--- a/README.md
+++ b/README.md
@@ -128,9 +128,10 @@ username or the note associated, you can use the flag `--full`. You can
 also use the flag `--field={field}` to get whatever default or custom
 field you want. The `--raw` flag will show the output as JSON. Run
 `rbw edit --field={field} <name>` to change an existing custom field on
-login, secure note, card, and identity entries: piped stdin is stored as
-the new value (trailing newlines are stripped), or an editor is opened
-when stdin is a terminal. Empty values are refused. SSH key entries and
+login, secure note, card, and identity entries. `rbw edit` syncs the
+vault before opening the editor, so it needs network access. Piped
+stdin is stored as the new value (trailing newlines are stripped), or an
+editor is opened when stdin is a terminal. Empty values are refused. SSH key entries and
 linked fields cannot be edited this way. `rbw get --list-custom-fields`
 lists the editable custom field names for an entry. In addition to
 matching against the name, you can pass a UUID as the name to search for

--- a/README.md
+++ b/README.md
@@ -131,12 +131,12 @@ field you want. The `--raw` flag will show the output as JSON. Run
 login, secure note, card, and identity entries. `rbw edit` syncs the
 vault before opening the editor, so it needs network access. Piped
 stdin is stored as the new value (trailing newlines are stripped), or an
-editor is opened when stdin is a terminal. Empty values are refused. SSH key entries and
-linked fields cannot be edited this way. `rbw get --list-custom-fields`
-lists the editable custom field names for an entry. In addition to
-matching against the name, you can pass a UUID as the name to search for
-the entry with that id, or a URL to search for an entry with a matching
-website entry.
+editor is opened when stdin is a terminal. Empty values are refused.
+SSH key entries and linked fields cannot be edited this way.
+`rbw get --list-custom-fields` lists the editable custom field names for
+an entry. In addition to matching against the name, you can pass a UUID
+as the name to search for the entry with that id, or a URL to search for
+an entry with a matching website entry.
 
 *Note to users of the official Bitwarden server (at bitwarden.com)*: The
 official server has a tendency to detect command line traffic as bot traffic

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -205,6 +205,9 @@ pub fn edit(
     folder_uuid: Option<&str>,
     history: &[crate::db::HistoryEntry],
     key: Option<&str>,
+    reprompt: crate::api::CipherRepromptType,
+    favorite: bool,
+    archived_date: Option<&str>,
 ) -> Result<(Option<String>, ())> {
     with_exchange_refresh_token(access_token, refresh_token, |access_token| {
         edit_once(
@@ -218,6 +221,9 @@ pub fn edit(
             folder_uuid,
             history,
             key,
+            reprompt,
+            favorite,
+            archived_date,
         )
     })
 }
@@ -233,6 +239,9 @@ fn edit_once(
     folder_uuid: Option<&str>,
     history: &[crate::db::HistoryEntry],
     key: Option<&str>,
+    reprompt: crate::api::CipherRepromptType,
+    favorite: bool,
+    archived_date: Option<&str>,
 ) -> Result<()> {
     let (client, _) = api_client()?;
     client.edit(
@@ -246,6 +255,9 @@ fn edit_once(
         folder_uuid,
         history,
         key,
+        reprompt,
+        favorite,
+        archived_date,
     )?;
     Ok(())
 }

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -193,7 +193,46 @@ fn add_once(
     Ok(())
 }
 
+/// 1.15-compatible cipher PUT. Does not send item key, revision, or
+/// favorite/archive — keyed items can be mixed-key corrupted. Use
+/// [`edit_with_meta`].
+#[deprecated(
+    note = "use edit_with_meta so item keys, revision, and favorite/archive are preserved"
+)]
 pub fn edit(
+    access_token: &str,
+    refresh_token: &str,
+    id: &str,
+    org_id: Option<&str>,
+    name: &str,
+    data: &crate::db::EntryData,
+    fields: &[crate::db::Field],
+    notes: Option<&str>,
+    folder_uuid: Option<&str>,
+    history: &[crate::db::HistoryEntry],
+) -> Result<(Option<String>, ())> {
+    edit_with_meta(
+        access_token,
+        refresh_token,
+        id,
+        org_id,
+        name,
+        data,
+        fields,
+        notes,
+        folder_uuid,
+        history,
+        &crate::db::CipherWriteMeta {
+            key: None,
+            reprompt: crate::api::CipherRepromptType::None,
+            favorite: false,
+            archived_date: None,
+            last_known_revision_date: None,
+        },
+    )
+}
+
+pub fn edit_with_meta(
     access_token: &str,
     refresh_token: &str,
     id: &str,
@@ -235,7 +274,7 @@ fn edit_once(
     meta: &crate::db::CipherWriteMeta<'_>,
 ) -> Result<()> {
     let (client, _) = api_client()?;
-    client.edit(
+    client.edit_with_meta(
         access_token,
         id,
         org_id,

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -204,10 +204,7 @@ pub fn edit(
     notes: Option<&str>,
     folder_uuid: Option<&str>,
     history: &[crate::db::HistoryEntry],
-    key: Option<&str>,
-    reprompt: crate::api::CipherRepromptType,
-    favorite: bool,
-    archived_date: Option<&str>,
+    meta: &crate::db::CipherWriteMeta<'_>,
 ) -> Result<(Option<String>, ())> {
     with_exchange_refresh_token(access_token, refresh_token, |access_token| {
         edit_once(
@@ -220,10 +217,7 @@ pub fn edit(
             notes,
             folder_uuid,
             history,
-            key,
-            reprompt,
-            favorite,
-            archived_date,
+            meta,
         )
     })
 }
@@ -238,10 +232,7 @@ fn edit_once(
     notes: Option<&str>,
     folder_uuid: Option<&str>,
     history: &[crate::db::HistoryEntry],
-    key: Option<&str>,
-    reprompt: crate::api::CipherRepromptType,
-    favorite: bool,
-    archived_date: Option<&str>,
+    meta: &crate::db::CipherWriteMeta<'_>,
 ) -> Result<()> {
     let (client, _) = api_client()?;
     client.edit(
@@ -254,10 +245,7 @@ fn edit_once(
         notes,
         folder_uuid,
         history,
-        key,
-        reprompt,
-        favorite,
-        archived_date,
+        meta,
     )?;
     Ok(())
 }

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -193,45 +193,6 @@ fn add_once(
     Ok(())
 }
 
-/// 1.15-compatible cipher PUT. Does not send item key, revision, or
-/// favorite/archive — keyed items can be mixed-key corrupted. Use
-/// [`edit_with_meta`].
-#[deprecated(
-    note = "use edit_with_meta so item keys, revision, and favorite/archive are preserved"
-)]
-pub fn edit(
-    access_token: &str,
-    refresh_token: &str,
-    id: &str,
-    org_id: Option<&str>,
-    name: &str,
-    data: &crate::db::EntryData,
-    fields: &[crate::db::Field],
-    notes: Option<&str>,
-    folder_uuid: Option<&str>,
-    history: &[crate::db::HistoryEntry],
-) -> Result<(Option<String>, ())> {
-    edit_with_meta(
-        access_token,
-        refresh_token,
-        id,
-        org_id,
-        name,
-        data,
-        fields,
-        notes,
-        folder_uuid,
-        history,
-        &crate::db::CipherWriteMeta {
-            key: None,
-            reprompt: crate::api::CipherRepromptType::None,
-            favorite: false,
-            archived_date: None,
-            last_known_revision_date: None,
-        },
-    )
-}
-
 pub fn edit_with_meta(
     access_token: &str,
     refresh_token: &str,

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -204,6 +204,7 @@ pub fn edit(
     notes: Option<&str>,
     folder_uuid: Option<&str>,
     history: &[crate::db::HistoryEntry],
+    key: Option<&str>,
 ) -> Result<(Option<String>, ())> {
     with_exchange_refresh_token(access_token, refresh_token, |access_token| {
         edit_once(
@@ -216,6 +217,7 @@ pub fn edit(
             notes,
             folder_uuid,
             history,
+            key,
         )
     })
 }
@@ -230,6 +232,7 @@ fn edit_once(
     notes: Option<&str>,
     folder_uuid: Option<&str>,
     history: &[crate::db::HistoryEntry],
+    key: Option<&str>,
 ) -> Result<()> {
     let (client, _) = api_client()?;
     client.edit(
@@ -242,6 +245,7 @@ fn edit_once(
         notes,
         folder_uuid,
         history,
+        key,
     )?;
     Ok(())
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -432,6 +432,8 @@ struct SyncResCipher {
     favorite: bool,
     #[serde(default, rename = "ArchivedDate", alias = "archivedDate")]
     archived_date: Option<String>,
+    #[serde(default, rename = "RevisionDate", alias = "revisionDate")]
+    revision_date: Option<String>,
 }
 
 impl SyncResCipher {
@@ -557,6 +559,7 @@ impl SyncResCipher {
             master_password_reprompt: self.reprompt,
             favorite: self.favorite,
             archived_date: self.archived_date.clone(),
+            revision_date: self.revision_date.clone(),
         })
     }
 }
@@ -793,6 +796,14 @@ struct CiphersPutReq {
     favorite: bool,
     #[serde(rename = "archivedDate")]
     archived_date: Option<String>,
+    // Official server only conflict-checks when this is present. An
+    // omitted value allows a stale full PUT to overwrite a password or
+    // notes another client just saved.
+    #[serde(
+        rename = "lastKnownRevisionDate",
+        skip_serializing_if = "Option::is_none"
+    )]
+    last_known_revision_date: Option<String>,
 }
 
 #[derive(serde::Serialize, Debug)]
@@ -1341,10 +1352,7 @@ impl Client {
         notes: Option<&str>,
         folder_uuid: Option<&str>,
         history: &[crate::db::HistoryEntry],
-        key: Option<&str>,
-        reprompt: CipherRepromptType,
-        favorite: bool,
-        archived_date: Option<&str>,
+        meta: &crate::db::CipherWriteMeta<'_>,
     ) -> Result<()> {
         let mut req = CiphersPutReq {
             ty: match data {
@@ -1378,10 +1386,14 @@ impl Client {
                     password: entry.password.clone(),
                 })
                 .collect(),
-            key: key.map(std::string::ToString::to_string),
-            reprompt,
-            favorite,
-            archived_date: archived_date
+            key: meta.key.map(std::string::ToString::to_string),
+            reprompt: meta.reprompt,
+            favorite: meta.favorite,
+            archived_date: meta
+                .archived_date
+                .map(std::string::ToString::to_string),
+            last_known_revision_date: meta
+                .last_known_revision_date
                 .map(std::string::ToString::to_string),
         };
         match data {
@@ -1482,6 +1494,9 @@ impl Client {
             reqwest::StatusCode::OK => Ok(()),
             reqwest::StatusCode::UNAUTHORIZED => {
                 Err(Error::RequestUnauthorized)
+            }
+            reqwest::StatusCode::CONFLICT => {
+                Err(Error::CipherRevisionConflict)
             }
             _ => Err(Error::RequestFailed {
                 status: res.status().as_u16(),

--- a/src/api.rs
+++ b/src/api.rs
@@ -1341,44 +1341,6 @@ impl Client {
         }
     }
 
-    /// 1.15-compatible cipher PUT. Does not send item key, revision, or
-    /// favorite/archive. Use [`Self::edit_with_meta`].
-    #[deprecated(
-        note = "use edit_with_meta so item keys, revision, and favorite/archive are preserved"
-    )]
-    pub fn edit(
-        &self,
-        access_token: &str,
-        id: &str,
-        org_id: Option<&str>,
-        name: &str,
-        data: &crate::db::EntryData,
-        fields: &[crate::db::Field],
-        notes: Option<&str>,
-        folder_uuid: Option<&str>,
-        history: &[crate::db::HistoryEntry],
-    ) -> Result<()> {
-        #[allow(deprecated)]
-        self.edit_with_meta(
-            access_token,
-            id,
-            org_id,
-            name,
-            data,
-            fields,
-            notes,
-            folder_uuid,
-            history,
-            &crate::db::CipherWriteMeta {
-                key: None,
-                reprompt: CipherRepromptType::None,
-                favorite: false,
-                archived_date: None,
-                last_known_revision_date: None,
-            },
-        )
-    }
-
     pub fn edit_with_meta(
         &self,
         access_token: &str,

--- a/src/api.rs
+++ b/src/api.rs
@@ -1341,7 +1341,45 @@ impl Client {
         }
     }
 
+    /// 1.15-compatible cipher PUT. Does not send item key, revision, or
+    /// favorite/archive. Use [`Self::edit_with_meta`].
+    #[deprecated(
+        note = "use edit_with_meta so item keys, revision, and favorite/archive are preserved"
+    )]
     pub fn edit(
+        &self,
+        access_token: &str,
+        id: &str,
+        org_id: Option<&str>,
+        name: &str,
+        data: &crate::db::EntryData,
+        fields: &[crate::db::Field],
+        notes: Option<&str>,
+        folder_uuid: Option<&str>,
+        history: &[crate::db::HistoryEntry],
+    ) -> Result<()> {
+        #[allow(deprecated)]
+        self.edit_with_meta(
+            access_token,
+            id,
+            org_id,
+            name,
+            data,
+            fields,
+            notes,
+            folder_uuid,
+            history,
+            &crate::db::CipherWriteMeta {
+                key: None,
+                reprompt: CipherRepromptType::None,
+                favorite: false,
+                archived_date: None,
+                last_known_revision_date: None,
+            },
+        )
+    }
+
+    pub fn edit_with_meta(
         &self,
         access_token: &str,
         id: &str,

--- a/src/api.rs
+++ b/src/api.rs
@@ -780,6 +780,7 @@ struct CiphersPutReq {
     secure_note: Option<CipherSecureNote>,
     #[serde(rename = "passwordHistory")]
     password_history: Vec<CiphersPutReqHistory>,
+    key: Option<String>,
 }
 
 #[derive(serde::Serialize, Debug)]
@@ -1328,6 +1329,7 @@ impl Client {
         notes: Option<&str>,
         folder_uuid: Option<&str>,
         history: &[crate::db::HistoryEntry],
+        key: Option<&str>,
     ) -> Result<()> {
         let mut req = CiphersPutReq {
             ty: match data {
@@ -1361,6 +1363,7 @@ impl Client {
                     password: entry.password.clone(),
                 })
                 .collect(),
+            key: key.map(std::string::ToString::to_string),
         };
         match data {
             crate::db::EntryData::Login {

--- a/src/api.rs
+++ b/src/api.rs
@@ -1490,18 +1490,12 @@ impl Client {
             .json(&req)
             .send()
             .map_err(|source| Error::Reqwest { source })?;
-        match res.status() {
-            reqwest::StatusCode::OK => Ok(()),
-            reqwest::StatusCode::UNAUTHORIZED => {
-                Err(Error::RequestUnauthorized)
-            }
-            reqwest::StatusCode::CONFLICT => {
-                Err(Error::CipherRevisionConflict)
-            }
-            _ => Err(Error::RequestFailed {
-                status: res.status().as_u16(),
-            }),
+        let status = res.status();
+        if status == reqwest::StatusCode::OK {
+            return Ok(());
         }
+        let body = res.text().unwrap_or_default();
+        Err(cipher_write_error(status, &body))
     }
 
     pub fn remove(&self, access_token: &str, id: &str) -> Result<()> {
@@ -1802,4 +1796,60 @@ fn classify_login_error(error_res: &ConnectErrorRes, code: u16) -> Error {
 
     log::warn!("unexpected error received during login: {error_res:?}");
     Error::RequestFailed { status: code }
+}
+
+fn cipher_write_error(status: reqwest::StatusCode, body: &str) -> Error {
+    // Official Bitwarden throws BadRequestException ("out of date") → 400.
+    // Vaultwarden uses err!("... out of date.") → also 400. Some forks
+    // might still use 409. Matching the body is what surfaces
+    // CipherRevisionConflict; status 409 is kept as a belt.
+    if status == reqwest::StatusCode::CONFLICT
+        || is_stale_cipher_message(body)
+    {
+        Error::CipherRevisionConflict
+    } else if status == reqwest::StatusCode::UNAUTHORIZED {
+        Error::RequestUnauthorized
+    } else {
+        Error::RequestFailed {
+            status: status.as_u16(),
+        }
+    }
+}
+
+fn is_stale_cipher_message(body: &str) -> bool {
+    body.to_ascii_lowercase().contains("out of date")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn revision_conflict_from_official_and_vaultwarden_bodies() {
+        assert!(matches!(
+            cipher_write_error(
+                reqwest::StatusCode::BAD_REQUEST,
+                "The item cannot be saved because it is out of date. Please reload and try again.",
+            ),
+            Error::CipherRevisionConflict
+        ));
+        assert!(matches!(
+            cipher_write_error(
+                reqwest::StatusCode::BAD_REQUEST,
+                r#"{"message":"The client copy of this cipher is out of date."}"#,
+            ),
+            Error::CipherRevisionConflict
+        ));
+        assert!(matches!(
+            cipher_write_error(reqwest::StatusCode::CONFLICT, ""),
+            Error::CipherRevisionConflict
+        ));
+        assert!(matches!(
+            cipher_write_error(
+                reqwest::StatusCode::BAD_REQUEST,
+                "Name is required",
+            ),
+            Error::RequestFailed { status: 400 }
+        ));
+    }
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -428,6 +428,10 @@ struct SyncResCipher {
     key: Option<String>,
     #[serde(rename = "Reprompt", alias = "reprompt")]
     reprompt: CipherRepromptType,
+    #[serde(default, rename = "Favorite", alias = "favorite")]
+    favorite: bool,
+    #[serde(default, rename = "ArchivedDate", alias = "archivedDate")]
+    archived_date: Option<String>,
 }
 
 impl SyncResCipher {
@@ -551,6 +555,8 @@ impl SyncResCipher {
             history,
             key: self.key.clone(),
             master_password_reprompt: self.reprompt,
+            favorite: self.favorite,
+            archived_date: self.archived_date.clone(),
         })
     }
 }
@@ -781,6 +787,12 @@ struct CiphersPutReq {
     #[serde(rename = "passwordHistory")]
     password_history: Vec<CiphersPutReqHistory>,
     key: Option<String>,
+    // Non-optional on the official server; omitting them resets the
+    // live cipher (see CipherRequestModel.ToCipherDetails).
+    reprompt: CipherRepromptType,
+    favorite: bool,
+    #[serde(rename = "archivedDate")]
+    archived_date: Option<String>,
 }
 
 #[derive(serde::Serialize, Debug)]
@@ -1330,6 +1342,9 @@ impl Client {
         folder_uuid: Option<&str>,
         history: &[crate::db::HistoryEntry],
         key: Option<&str>,
+        reprompt: CipherRepromptType,
+        favorite: bool,
+        archived_date: Option<&str>,
     ) -> Result<()> {
         let mut req = CiphersPutReq {
             ty: match data {
@@ -1364,6 +1379,10 @@ impl Client {
                 })
                 .collect(),
             key: key.map(std::string::ToString::to_string),
+            reprompt,
+            favorite,
+            archived_date: archived_date
+                .map(std::string::ToString::to_string),
         };
         match data {
             crate::db::EntryData::Login {

--- a/src/bin/rbw-agent/actions.rs
+++ b/src/bin/rbw-agent/actions.rs
@@ -527,7 +527,6 @@ pub async fn sync(
     ) = rbw::actions::sync(&access_token, &refresh_token)
         .await
         .context("failed to sync database from server")?;
-    state.lock().await.set_master_password_reprompt(&entries);
     if let Some(access_token) = access_token {
         db.access_token = Some(access_token);
     }
@@ -535,7 +534,19 @@ pub async fn sync(
     db.protected_private_key = Some(protected_private_key);
     db.protected_org_keys = protected_org_keys;
     db.entries = entries;
-    save_db(&db).await?;
+    // Disk first, then the in-memory ciphertext set, under the same
+    // lock. The reverse order (or updating memory before a failed
+    // save) leaves the set matching the server while the on-disk
+    // cache still has the previous vault: decrypting an old hidden
+    // value would miss the set and skip master-password reprompt.
+    // Holding the lock across the save closes the window where a
+    // concurrent decrypt would see new disk bytes against the old
+    // set (the original skip-prompt bug this sync exists to fix).
+    {
+        let mut state = state.lock().await;
+        save_db(&db).await?;
+        state.set_master_password_reprompt(&db.entries);
+    }
 
     if let Err(e) = subscribe_to_notifications(state.clone()).await {
         eprintln!("failed to subscribe to notifications: {e}");

--- a/src/bin/rbw-agent/actions.rs
+++ b/src/bin/rbw-agent/actions.rs
@@ -692,6 +692,7 @@ pub async fn encrypt(
     sock: &mut crate::sock::Sock,
     state: std::sync::Arc<tokio::sync::Mutex<crate::state::State>>,
     plaintext: &str,
+    entry_key: Option<&str>,
     org_id: Option<&str>,
 ) -> anyhow::Result<()> {
     let state = state.lock().await;
@@ -700,8 +701,20 @@ pub async fn encrypt(
             "failed to find encryption keys in in-memory state"
         ));
     };
+    let entry_keys = if let Some(entry_key) = entry_key {
+        let key_cipherstring =
+            rbw::cipherstring::CipherString::new(entry_key)
+                .context("failed to parse individual item encryption key")?;
+        Some(rbw::locked::Keys::new(
+            key_cipherstring.decrypt_locked_symmetric(keys).context(
+                "failed to decrypt individual item encryption key",
+            )?,
+        ))
+    } else {
+        None
+    };
     let cipherstring = rbw::cipherstring::CipherString::encrypt_symmetric(
-        keys,
+        entry_keys.as_ref().unwrap_or(keys),
         plaintext.as_bytes(),
     )
     .context("failed to encrypt plaintext secret")?;

--- a/src/bin/rbw-agent/agent.rs
+++ b/src/bin/rbw-agent/agent.rs
@@ -162,11 +162,16 @@ async fn handle_request(
             .await?;
             true
         }
-        rbw::protocol::Action::Encrypt { plaintext, org_id } => {
+        rbw::protocol::Action::Encrypt {
+            plaintext,
+            entry_key,
+            org_id,
+        } => {
             crate::actions::encrypt(
                 sock,
                 state.clone(),
                 plaintext,
+                entry_key.as_deref(),
                 org_id.as_deref(),
             )
             .await?;

--- a/src/bin/rbw/actions.rs
+++ b/src/bin/rbw/actions.rs
@@ -107,6 +107,7 @@ pub fn decrypt(
 
 pub fn encrypt(
     plaintext: &str,
+    entry_key: Option<&str>,
     org_id: Option<&str>,
 ) -> anyhow::Result<String> {
     let mut sock = connect()?;
@@ -114,6 +115,7 @@ pub fn encrypt(
         get_environment(),
         rbw::protocol::Action::Encrypt {
             plaintext: plaintext.to_string(),
+            entry_key: entry_key.map(std::string::ToString::to_string),
             org_id: org_id.map(std::string::ToString::to_string),
         },
     ))?;

--- a/src/bin/rbw/commands.rs
+++ b/src/bin/rbw/commands.rs
@@ -1240,14 +1240,22 @@ fn unique_help_markers(current: &str) -> (String, String) {
     }
 }
 
-fn field_help(boolean: bool, start: &str, end: &str) -> String {
-    let body = if boolean {
-        "# Enter true or false (nothing else).\n# Empty values are refused."
+const HELP_BODY: &str =
+    "# The content of this file will be stored as the custom field value.\n\
+     # Empty values are refused.";
+const HELP_BODY_BOOLEAN: &str =
+    "# Enter true or false (nothing else).\n# Empty values are refused.";
+
+fn help_body(boolean: bool) -> &'static str {
+    if boolean {
+        HELP_BODY_BOOLEAN
     } else {
-        "# The content of this file will be stored as the custom field value.\n\
-         # Empty values are refused."
-    };
-    format!("\n{start}\n{body}\n{end}\n")
+        HELP_BODY
+    }
+}
+
+fn field_help(boolean: bool, start: &str, end: &str) -> String {
+    format!("\n{start}\n{}\n{end}\n", help_body(boolean))
 }
 
 pub fn config_show() -> anyhow::Result<()> {
@@ -1805,14 +1813,18 @@ pub fn edit(
     let mut db = load_db()?;
     let entry = find_db_entry(&db, name, username, folder, ignore_case)
         .with_context(|| format!("couldn't find entry for '{desc}'"))?;
-    let decrypted = decrypt_cipher(&entry)?;
 
     if let Some(field_name) = field {
-        edit_custom_field(&mut db, &entry, &decrypted, field_name)?;
+        // Decrypt only the target field. Full decrypt_cipher would pinentry
+        // once per hidden value, and encrypt_field_on_entry used to do it
+        // a second time.
+        edit_custom_field(&mut db, &entry, field_name)?;
         return Ok(());
     }
 
-    let (data, fields, notes, history) = match &decrypted.data {
+    let decrypted = decrypt_cipher(&entry)?;
+
+    let (data, fields, notes, history, unsaved) = match &decrypted.data {
         DecryptedData::Login { password, .. } => {
             let mut contents =
                 format!("{}\n", password.as_deref().unwrap_or(""));
@@ -1821,7 +1833,7 @@ pub fn edit(
             }
 
             let contents = rbw::edit::edit(&contents, HELP_PW)?;
-
+            let unsaved = contents.clone();
             let (password, notes) = parse_editor(&contents);
             let password = password
                 .map(|password| {
@@ -1871,7 +1883,7 @@ pub fn edit(
                 uris: entry_uris.clone(),
                 totp: entry_totp.clone(),
             };
-            (data, entry.fields.clone(), notes, history)
+            (data, entry.fields.clone(), notes, history, unsaved)
         }
         DecryptedData::SecureNote => {
             let data = rbw::db::EntryData::SecureNote {};
@@ -1881,6 +1893,7 @@ pub fn edit(
                 |notes| format!("{notes}\n"),
             );
             let contents = rbw::edit::edit(&editor_content, HELP_NOTES)?;
+            let unsaved = contents.clone();
 
             // prepend blank line to be parsed as pw by `parse_editor`
             let (_, notes) = parse_editor(&format!("\n{contents}\n"));
@@ -1895,7 +1908,13 @@ pub fn edit(
                 })
                 .transpose()?;
 
-            (data, entry.fields.clone(), notes, entry.history.clone())
+            (
+                data,
+                entry.fields.clone(),
+                notes,
+                entry.history.clone(),
+                unsaved,
+            )
         }
         _ => {
             return Err(anyhow::anyhow!(
@@ -1904,8 +1923,43 @@ pub fn edit(
         }
     };
 
-    put_cipher(&mut db, &entry, &data, &fields, notes.as_deref(), &history)?;
+    if let Err(err) = put_cipher(
+        &mut db,
+        &entry,
+        &data,
+        &fields,
+        notes.as_deref(),
+        &history,
+    ) {
+        if is_revision_conflict(&err) {
+            let path = persist_unsaved_edit(&unsaved)?;
+            return Err(err).context(format!(
+                "unsaved edit written to {}",
+                path.display()
+            ));
+        }
+        return Err(err);
+    }
     Ok(())
+}
+
+fn is_revision_conflict(err: &anyhow::Error) -> bool {
+    matches!(
+        err.downcast_ref::<rbw::error::Error>(),
+        Some(rbw::error::Error::CipherRevisionConflict)
+    )
+}
+
+fn persist_unsaved_edit(buf: &str) -> anyhow::Result<std::path::PathBuf> {
+    use std::io::Write as _;
+    let mut tmp = tempfile::NamedTempFile::new()
+        .context("failed to create unsaved-edit tempfile")?;
+    tmp.write_all(buf.as_bytes())
+        .context("failed to write unsaved-edit tempfile")?;
+    let (_, path) = tmp.keep().map_err(|e| {
+        anyhow::anyhow!("failed to persist unsaved edit: {e}")
+    })?;
+    Ok(path)
 }
 
 fn put_cipher(
@@ -1934,18 +1988,13 @@ fn put_cipher(
     )?;
     if let Some(new_token) = new_token {
         db.access_token = Some(new_token);
+        save_db(db)?;
     }
-    // Patch the local snapshot so `rbw get` sees the write without a
-    // second full-vault sync. The next edit syncs before resolving the
-    // selector, so a slightly stale revision_date is harmless.
-    if let Some(slot) = db.entries.iter_mut().find(|item| item.id == entry.id)
-    {
-        slot.data = data.clone();
-        slot.fields = fields.to_vec();
-        slot.notes = notes.map(str::to_string);
-        slot.history = history.to_vec();
-    }
-    save_db(db)?;
+    // Agent rebuilds the master-password-reprompt ciphertext set only
+    // during sync. Patching the on-disk db is not enough: a following
+    // `rbw get` would decrypt the new hidden value without a prompt.
+    crate::actions::sync()?;
+    *db = load_db()?;
     Ok(())
 }
 
@@ -2027,13 +2076,27 @@ fn strip_help_block(
              or remove it entirely"
         ),
     };
-    if combined.contains(start) || combined.contains(end) {
+    if combined.contains(start)
+        || combined.contains(end)
+        || contains_help_body(&combined)
+    {
         anyhow::bail!(
             "editor output still contains the help text; \
              remove it or leave the help block intact"
         );
     }
     Ok(strip_trailing_newlines(&combined))
+}
+
+fn contains_help_body(text: &str) -> bool {
+    help_body(false)
+        .lines()
+        .chain(help_body(true).lines())
+        .filter(|line| !line.is_empty())
+        .any(|help_line| {
+            text.lines()
+                .any(|line| line.trim_end_matches('\r') == help_line)
+        })
 }
 
 fn read_custom_field_value(
@@ -2090,26 +2153,76 @@ fn validate_boolean_field(
 fn edit_custom_field(
     db: &mut rbw::db::Db,
     entry: &rbw::db::Entry,
-    decrypted: &DecryptedCipher,
     field_name: &str,
 ) -> anyhow::Result<()> {
     // Client::edit has no SSH key PUT payload (unreachable!). Login,
     // Secure Note, Card, and Identity all have typed PUT bodies.
-    if matches!(decrypted.data, DecryptedData::SshKey { .. }) {
+    if matches!(entry.data, rbw::db::EntryData::SshKey { .. }) {
         anyhow::bail!(
             "custom field edits are not supported for SSH key entries"
         );
     }
 
-    let idx = find_custom_field_index(&decrypted.fields, field_name)?;
-    let field = &decrypted.fields[idx];
-    if field.ty == Some(rbw::api::FieldType::Linked) {
+    let (idx, ty) = named_custom_field(entry, field_name)?;
+    if ty == Some(rbw::api::FieldType::Linked) {
         anyhow::bail!("linked custom fields cannot be edited as values");
     }
 
-    let current = field.value.clone().unwrap_or_default();
-    let new_value = read_custom_field_value(&current, field.ty)?;
-    put_field_plaintext(db, entry, field_name, &new_value)
+    let current = decrypt_custom_field_value(entry, idx)?;
+    let new_value = read_custom_field_value(&current, ty)?;
+    let original_ct = entry.fields[idx].value.clone();
+    put_field_plaintext(
+        db,
+        entry,
+        field_name,
+        &new_value,
+        original_ct.as_deref(),
+    )
+}
+
+fn named_custom_field(
+    entry: &rbw::db::Entry,
+    field_name: &str,
+) -> anyhow::Result<(usize, Option<rbw::api::FieldType>)> {
+    let mut decrypted_names = Vec::with_capacity(entry.fields.len());
+    for field in &entry.fields {
+        let name = field
+            .name
+            .as_ref()
+            .map(|name| {
+                crate::actions::decrypt(
+                    name,
+                    entry.key.as_deref(),
+                    entry.org_id.as_deref(),
+                )
+            })
+            .transpose()?;
+        decrypted_names.push(DecryptedField {
+            name,
+            value: None,
+            ty: field.ty,
+        });
+    }
+    let idx = find_custom_field_index(&decrypted_names, field_name)?;
+    Ok((idx, entry.fields[idx].ty))
+}
+
+fn decrypt_custom_field_value(
+    entry: &rbw::db::Entry,
+    idx: usize,
+) -> anyhow::Result<String> {
+    entry.fields[idx]
+        .value
+        .as_ref()
+        .map(|value| {
+            crate::actions::decrypt(
+                value,
+                entry.key.as_deref(),
+                entry.org_id.as_deref(),
+            )
+        })
+        .transpose()
+        .map(std::option::Option::unwrap_or_default)
 }
 
 fn put_field_plaintext(
@@ -2117,20 +2230,13 @@ fn put_field_plaintext(
     entry: &rbw::db::Entry,
     field_name: &str,
     plaintext: &str,
+    original_ciphertext: Option<&str>,
 ) -> anyhow::Result<()> {
     let (data, fields, notes, history) =
-        encrypt_field_on_entry(entry, field_name, plaintext)?;
+        encrypt_named_field(entry, field_name, plaintext)?;
     match put_cipher(db, entry, &data, &fields, notes.as_deref(), &history) {
         Ok(()) => Ok(()),
-        Err(err)
-            if matches!(
-                err.downcast_ref::<rbw::error::Error>(),
-                Some(rbw::error::Error::CipherRevisionConflict)
-            ) =>
-        {
-            // Re-apply only the field on a fresh snapshot. Retrying the
-            // original full PUT would overwrite a password another client
-            // just saved.
+        Err(err) if is_revision_conflict(&err) => {
             crate::actions::sync()?;
             *db = load_db()?;
             let entry = db
@@ -2141,15 +2247,24 @@ fn put_field_plaintext(
                 .ok_or_else(|| {
                     anyhow::anyhow!("entry disappeared after conflict sync")
                 })?;
+            let (idx, ty) = named_custom_field(&entry, field_name)?;
+            if entry.fields[idx].value.as_deref() != original_ciphertext {
+                // Another client changed this same field. Rebase would
+                // use the new revision and silently overwrite them.
+                return Err(err).context(
+                    "the same custom field was changed on the server",
+                );
+            }
+            validate_boolean_field(ty, plaintext)?;
             let (data, fields, notes, history) =
-                encrypt_field_on_entry(&entry, field_name, plaintext)?;
+                encrypt_named_field(&entry, field_name, plaintext)?;
             put_cipher(db, &entry, &data, &fields, notes.as_deref(), &history)
         }
         Err(err) => Err(err),
     }
 }
 
-fn encrypt_field_on_entry(
+fn encrypt_named_field(
     entry: &rbw::db::Entry,
     field_name: &str,
     plaintext: &str,
@@ -2159,14 +2274,8 @@ fn encrypt_field_on_entry(
     Option<String>,
     Vec<rbw::db::HistoryEntry>,
 )> {
-    let decrypted = decrypt_cipher(entry)?;
-    if matches!(decrypted.data, DecryptedData::SshKey { .. }) {
-        anyhow::bail!(
-            "custom field edits are not supported for SSH key entries"
-        );
-    }
-    let idx = find_custom_field_index(&decrypted.fields, field_name)?;
-    if decrypted.fields[idx].ty == Some(rbw::api::FieldType::Linked) {
+    let (idx, ty) = named_custom_field(entry, field_name)?;
+    if ty == Some(rbw::api::FieldType::Linked) {
         anyhow::bail!("linked custom fields cannot be edited as values");
     }
     let encrypted = crate::actions::encrypt(
@@ -4614,6 +4723,8 @@ mod test {
             .is_err());
         let end_before_start = format!("value\n{end}\n{start}\n");
         assert!(strip_help_block(&end_before_start, start, end).is_err());
+        let leftover_body = format!("value\n{HELP_BODY}\n");
+        assert!(strip_help_block(&leftover_body, start, end).is_err());
     }
 
     #[test]

--- a/src/bin/rbw/commands.rs
+++ b/src/bin/rbw/commands.rs
@@ -1230,7 +1230,7 @@ const HELP_NOTES: &str = r"
 
 const HELP_FIELD: &str = r"
 # The content of this file will be stored as the custom field value.
-# Lines with leading # will be ignored.
+# This help text is not saved.
 ";
 
 pub fn config_show() -> anyhow::Result<()> {
@@ -1575,26 +1575,26 @@ pub fn add(
     let mut access_token = db.access_token.as_ref().unwrap().clone();
     let refresh_token = db.refresh_token.as_ref().unwrap();
 
-    let name = crate::actions::encrypt(name, None)?;
+    let name = crate::actions::encrypt(name, None, None)?;
 
     let username = username
-        .map(|username| crate::actions::encrypt(username, None))
+        .map(|username| crate::actions::encrypt(username, None, None))
         .transpose()?;
 
     let contents = rbw::edit::edit("", HELP_PW)?;
 
     let (password, notes) = parse_editor(&contents);
     let password = password
-        .map(|password| crate::actions::encrypt(&password, None))
+        .map(|password| crate::actions::encrypt(&password, None, None))
         .transpose()?;
     let notes = notes
-        .map(|notes| crate::actions::encrypt(&notes, None))
+        .map(|notes| crate::actions::encrypt(&notes, None, None))
         .transpose()?;
     let uris: Vec<_> = uris
         .iter()
         .map(|uri| {
             Ok(rbw::db::Uri {
-                uri: crate::actions::encrypt(&uri.0, None)?,
+                uri: crate::actions::encrypt(&uri.0, None, None)?,
                 match_type: uri.1,
             })
         })
@@ -1627,7 +1627,7 @@ pub fn add(
             let (new_access_token, id) = rbw::actions::create_folder(
                 &access_token,
                 refresh_token,
-                &crate::actions::encrypt(folder_name, None)?,
+                &crate::actions::encrypt(folder_name, None, None)?,
             )?;
             if let Some(new_access_token) = new_access_token {
                 access_token.clone_from(&new_access_token);
@@ -1680,16 +1680,16 @@ pub fn generate(
         let mut access_token = db.access_token.as_ref().unwrap().clone();
         let refresh_token = db.refresh_token.as_ref().unwrap();
 
-        let name = crate::actions::encrypt(name, None)?;
+        let name = crate::actions::encrypt(name, None, None)?;
         let username = username
-            .map(|username| crate::actions::encrypt(username, None))
+            .map(|username| crate::actions::encrypt(username, None, None))
             .transpose()?;
-        let password = crate::actions::encrypt(&password, None)?;
+        let password = crate::actions::encrypt(&password, None, None)?;
         let uris: Vec<_> = uris
             .iter()
             .map(|uri| {
                 Ok(rbw::db::Uri {
-                    uri: crate::actions::encrypt(&uri.0, None)?,
+                    uri: crate::actions::encrypt(&uri.0, None, None)?,
                     match_type: uri.1,
                 })
             })
@@ -1722,7 +1722,7 @@ pub fn generate(
                 let (new_access_token, id) = rbw::actions::create_folder(
                     &access_token,
                     refresh_token,
-                    &crate::actions::encrypt(folder_name, None)?,
+                    &crate::actions::encrypt(folder_name, None, None)?,
                 )?;
                 if let Some(new_access_token) = new_access_token {
                     access_token.clone_from(&new_access_token);
@@ -1801,13 +1801,18 @@ pub fn edit(
                 .map(|password| {
                     crate::actions::encrypt(
                         &password,
+                        entry.key.as_deref(),
                         entry.org_id.as_deref(),
                     )
                 })
                 .transpose()?;
             let notes = notes
                 .map(|notes| {
-                    crate::actions::encrypt(&notes, entry.org_id.as_deref())
+                    crate::actions::encrypt(
+                        &notes,
+                        entry.key.as_deref(),
+                        entry.org_id.as_deref(),
+                    )
                 })
                 .transpose()?;
             let mut history = entry.history.clone();
@@ -1856,7 +1861,11 @@ pub fn edit(
 
             let notes = notes
                 .map(|notes| {
-                    crate::actions::encrypt(&notes, entry.org_id.as_deref())
+                    crate::actions::encrypt(
+                        &notes,
+                        entry.key.as_deref(),
+                        entry.org_id.as_deref(),
+                    )
                 })
                 .transpose()?;
 
@@ -1880,6 +1889,7 @@ pub fn edit(
         notes.as_deref(),
         entry.folder_id.as_deref(),
         &history,
+        entry.key.as_deref(),
     )? {
         db.access_token = Some(access_token);
         save_db(&db)?;
@@ -1931,11 +1941,21 @@ fn strip_trailing_newlines(s: &str) -> String {
     s.trim_end_matches(['\n', '\r']).to_string()
 }
 
-fn strip_comment_lines(s: &str) -> String {
-    s.lines()
-        .filter(|line| !line.starts_with('#'))
-        .collect::<Vec<_>>()
-        .join("\n")
+fn strip_appended_help(raw: &str, help: &str) -> String {
+    let help_trim = help.trim_end_matches(['\n', '\r']);
+    let mut s = raw;
+    if let Some(prefix) = s.strip_suffix(help) {
+        s = prefix;
+    } else if let Some(without_nl) = s.strip_suffix('\n') {
+        if let Some(prefix) = without_nl.strip_suffix(help) {
+            s = prefix;
+        } else if let Some(prefix) = without_nl.strip_suffix(help_trim) {
+            s = prefix;
+        }
+    } else if let Some(prefix) = s.strip_suffix(help_trim) {
+        s = prefix;
+    }
+    strip_trailing_newlines(s)
 }
 
 fn read_custom_field_value(current: &str) -> anyhow::Result<String> {
@@ -1944,12 +1964,30 @@ fn read_custom_field_value(current: &str) -> anyhow::Result<String> {
     let value = if piped {
         strip_trailing_newlines(&raw)
     } else {
-        strip_trailing_newlines(&strip_comment_lines(&raw))
+        strip_appended_help(&raw, HELP_FIELD)
     };
     if value.is_empty() {
         anyhow::bail!("refusing to set an empty custom field value");
     }
     Ok(value)
+}
+
+fn validate_custom_field_value(
+    ty: Option<rbw::api::FieldType>,
+    value: &str,
+) -> anyhow::Result<()> {
+    match ty {
+        Some(rbw::api::FieldType::Linked) => {
+            anyhow::bail!("linked custom fields cannot be edited as values")
+        }
+        Some(rbw::api::FieldType::Boolean) => {
+            if value != "true" && value != "false" {
+                anyhow::bail!("boolean custom fields must be true or false");
+            }
+            Ok(())
+        }
+        _ => Ok(()),
+    }
 }
 
 fn edit_custom_field(
@@ -1958,11 +1996,26 @@ fn edit_custom_field(
     decrypted: &DecryptedCipher,
     field_name: &str,
 ) -> anyhow::Result<()> {
+    if matches!(decrypted.data, DecryptedData::SshKey { .. }) {
+        anyhow::bail!(
+            "custom field edits are not supported for SSH key entries"
+        );
+    }
+
     let idx = find_custom_field_index(&decrypted.fields, field_name)?;
-    let current = decrypted.fields[idx].value.clone().unwrap_or_default();
+    let field = &decrypted.fields[idx];
+    if field.ty == Some(rbw::api::FieldType::Linked) {
+        anyhow::bail!("linked custom fields cannot be edited as values");
+    }
+
+    let current = field.value.clone().unwrap_or_default();
     let new_value = read_custom_field_value(&current)?;
-    let encrypted =
-        crate::actions::encrypt(&new_value, entry.org_id.as_deref())?;
+    validate_custom_field_value(field.ty, &new_value)?;
+    let encrypted = crate::actions::encrypt(
+        &new_value,
+        entry.key.as_deref(),
+        entry.org_id.as_deref(),
+    )?;
 
     let mut fields = entry.fields.clone();
     fields[idx].value = Some(encrypted);
@@ -1980,6 +2033,7 @@ fn edit_custom_field(
         entry.notes.as_deref(),
         entry.folder_id.as_deref(),
         &entry.history,
+        entry.key.as_deref(),
     )? {
         db.access_token = Some(access_token);
         save_db(db)?;
@@ -4332,8 +4386,49 @@ mod test {
     }
 
     #[test]
-    fn test_strip_comment_lines() {
-        assert_eq!(strip_comment_lines("secret\n# ignored\n"), "secret");
-        assert_eq!(strip_comment_lines("# only comments\n"), "");
+    fn test_strip_appended_help_keeps_user_hash_lines() {
+        let contents = format!("value\n#keep{HELP_FIELD}");
+        assert_eq!(
+            strip_appended_help(&contents, HELP_FIELD),
+            "value\n#keep"
+        );
+        let with_extra_nl = format!("value\n#keep{HELP_FIELD}\n");
+        assert_eq!(
+            strip_appended_help(&with_extra_nl, HELP_FIELD),
+            "value\n#keep"
+        );
+        assert_eq!(
+            strip_appended_help("just-piped\n", HELP_FIELD),
+            "just-piped"
+        );
+    }
+
+    #[test]
+    fn test_validate_custom_field_value() {
+        assert!(validate_custom_field_value(
+            Some(rbw::api::FieldType::Hidden),
+            "any"
+        )
+        .is_ok());
+        assert!(validate_custom_field_value(
+            Some(rbw::api::FieldType::Boolean),
+            "true"
+        )
+        .is_ok());
+        assert!(validate_custom_field_value(
+            Some(rbw::api::FieldType::Boolean),
+            "false"
+        )
+        .is_ok());
+        assert!(validate_custom_field_value(
+            Some(rbw::api::FieldType::Boolean),
+            "yes"
+        )
+        .is_err());
+        assert!(validate_custom_field_value(
+            Some(rbw::api::FieldType::Linked),
+            "anything"
+        )
+        .is_err());
     }
 }

--- a/src/bin/rbw/commands.rs
+++ b/src/bin/rbw/commands.rs
@@ -1608,9 +1608,9 @@ pub fn add(
     // unwrap is safe here because the call to unlock above is guaranteed to
     // populate these or error
 
-    let name = crate::actions::encrypt(name, None, None)?;
+    let encrypted_name = crate::actions::encrypt(name, None, None)?;
 
-    let username = username
+    let encrypted_username = username
         .map(|username| crate::actions::encrypt(username, None, None))
         .transpose()?;
 
@@ -1618,14 +1618,21 @@ pub fn add(
     after_editor(
         source,
         &contents,
-        add_after_editor(&mut db, &name, username, uris, folder, &contents),
+        add_after_editor(
+            &mut db,
+            &encrypted_name,
+            encrypted_username,
+            uris,
+            folder,
+            &contents,
+        ),
     )
 }
 
 fn add_after_editor(
     db: &mut rbw::db::Db,
-    name: &str,
-    username: Option<String>,
+    encrypted_name: &str,
+    encrypted_username: Option<String>,
     uris: &[(String, Option<rbw::api::UriMatchType>)],
     folder: Option<&str>,
     contents: &str,
@@ -1688,24 +1695,27 @@ fn add_after_editor(
         }
     }
 
-    if let (Some(access_token), ()) = rbw::actions::add(
+    let (new_token, ()) = rbw::actions::add(
         &access_token,
         &refresh_token,
-        name,
+        encrypted_name,
         &rbw::db::EntryData::Login {
-            username,
+            username: encrypted_username,
             password,
             uris,
             totp: None,
         },
         notes.as_deref(),
         folder_id.as_deref(),
-    )? {
-        db.access_token = Some(access_token);
-        save_db(db)?;
-    }
-
-    refresh_local_cache()
+    )?;
+    after_server_write(|| {
+        if let Some(new_token) = new_token {
+            db.access_token = Some(new_token);
+            save_db(db)?;
+        }
+        crate::actions::sync()?;
+        Ok(())
+    })
 }
 
 pub fn generate(
@@ -1781,7 +1791,7 @@ pub fn generate(
             }
         }
 
-        if let (Some(access_token), ()) = rbw::actions::add(
+        let (new_token, ()) = rbw::actions::add(
             &access_token,
             refresh_token,
             &name,
@@ -1793,12 +1803,15 @@ pub fn generate(
             },
             None,
             folder_id.as_deref(),
-        )? {
-            db.access_token = Some(access_token);
-            save_db(&db)?;
-        }
-
-        refresh_local_cache()?;
+        )?;
+        after_server_write(|| {
+            if let Some(new_token) = new_token {
+                db.access_token = Some(new_token);
+                save_db(&db)?;
+            }
+            crate::actions::sync()?;
+            Ok(())
+        })?;
     }
 
     Ok(())
@@ -2051,8 +2064,10 @@ impl std::fmt::Display for LocalCacheRefreshFailed {
 
 impl std::error::Error for LocalCacheRefreshFailed {}
 
-fn refresh_local_cache() -> anyhow::Result<()> {
-    crate::actions::sync().context(LocalCacheRefreshFailed)
+fn after_server_write<T>(
+    op: impl FnOnce() -> anyhow::Result<T>,
+) -> anyhow::Result<T> {
+    op().context(LocalCacheRefreshFailed)
 }
 
 fn is_local_cache_refresh_failed(err: &anyhow::Error) -> bool {
@@ -2094,19 +2109,19 @@ fn put_cipher(
         history,
         &meta,
     )?;
-    if let Some(new_token) = new_token {
-        db.access_token = Some(new_token);
-        save_db(db)?;
-    }
     // Agent rebuilds the master-password-reprompt ciphertext set only
-    // during sync, and only after the new vault is on disk. A failed
-    // refresh here means disk and the in-memory set still match each
-    // other (both stale versus the server). Fail closed with exit
-    // status 2: the PUT succeeded, but this process cannot claim a
-    // consistent local view. Callers must not retry the edit.
-    refresh_local_cache()?;
-    *db = load_db()?;
-    Ok(())
+    // during sync, and only after the new vault is on disk. Any local
+    // failure after the PUT (token save, sync, reload) is exit 2: the
+    // server write landed; callers must not retry it.
+    after_server_write(|| {
+        if let Some(new_token) = new_token {
+            db.access_token = Some(new_token);
+            save_db(db)?;
+        }
+        crate::actions::sync()?;
+        *db = load_db()?;
+        Ok(())
+    })
 }
 
 fn find_custom_field_index(
@@ -2376,6 +2391,7 @@ fn put_field_plaintext(
     match put_cipher(db, entry, &data, &fields, notes.as_deref(), &history) {
         Ok(()) => Ok(()),
         Err(err) if is_revision_conflict(&err) => {
+            // PUT did not land. A failed rebase sync is still exit 1.
             crate::actions::sync()?;
             *db = load_db()?;
             let entry = db
@@ -4981,6 +4997,18 @@ mod test {
         assert!(msg.contains("put failed"));
         assert!(msg.contains("the piped value was not written to disk"));
         assert!(!msg.contains("plaintext you just typed"));
+    }
+
+    #[test]
+    fn test_after_server_write_marks_exit_2() {
+        let err = after_server_write(|| {
+            Err::<(), _>(anyhow::anyhow!("save_db failed"))
+        })
+        .unwrap_err();
+        assert_eq!(exit_status(&err), 2);
+        let msg = format!("{err:#}");
+        assert!(msg.contains("save_db failed"));
+        assert!(msg.contains("do not retry the write"));
     }
 
     #[test]

--- a/src/bin/rbw/commands.rs
+++ b/src/bin/rbw/commands.rs
@@ -1608,7 +1608,8 @@ pub fn add(
     // unwrap is safe here because the call to unlock above is guaranteed to
     // populate these or error
     let mut access_token = db.access_token.as_ref().unwrap().clone();
-    let refresh_token = db.refresh_token.as_ref().unwrap();
+    // Cloned so the post-editor closure can mutably borrow `db`.
+    let refresh_token = db.refresh_token.as_ref().unwrap().clone();
 
     let name = crate::actions::encrypt(name, None, None)?;
 
@@ -1616,83 +1617,91 @@ pub fn add(
         .map(|username| crate::actions::encrypt(username, None, None))
         .transpose()?;
 
-    let contents = rbw::edit::edit("", HELP_PW)?;
+    let (contents, source) = rbw::edit::edit_from("", HELP_PW)?;
+    after_editor(
+        source,
+        &contents,
+        (|| {
+            let (password, notes) = parse_editor(&contents);
+            let password = password
+                .map(|password| {
+                    crate::actions::encrypt(&password, None, None)
+                })
+                .transpose()?;
+            let notes = notes
+                .map(|notes| crate::actions::encrypt(&notes, None, None))
+                .transpose()?;
+            let uris: Vec<_> = uris
+                .iter()
+                .map(|uri| {
+                    Ok(rbw::db::Uri {
+                        uri: crate::actions::encrypt(&uri.0, None, None)?,
+                        match_type: uri.1,
+                    })
+                })
+                .collect::<anyhow::Result<_>>()?;
 
-    let (password, notes) = parse_editor(&contents);
-    let password = password
-        .map(|password| crate::actions::encrypt(&password, None, None))
-        .transpose()?;
-    let notes = notes
-        .map(|notes| crate::actions::encrypt(&notes, None, None))
-        .transpose()?;
-    let uris: Vec<_> = uris
-        .iter()
-        .map(|uri| {
-            Ok(rbw::db::Uri {
-                uri: crate::actions::encrypt(&uri.0, None, None)?,
-                match_type: uri.1,
-            })
-        })
-        .collect::<anyhow::Result<_>>()?;
+            let mut folder_id = None;
+            if let Some(folder_name) = folder {
+                let (new_access_token, folders) = rbw::actions::list_folders(
+                    &access_token,
+                    &refresh_token,
+                )?;
+                if let Some(new_access_token) = new_access_token {
+                    access_token.clone_from(&new_access_token);
+                    db.access_token = Some(new_access_token);
+                    save_db(&db)?;
+                }
 
-    let mut folder_id = None;
-    if let Some(folder_name) = folder {
-        let (new_access_token, folders) =
-            rbw::actions::list_folders(&access_token, refresh_token)?;
-        if let Some(new_access_token) = new_access_token {
-            access_token.clone_from(&new_access_token);
-            db.access_token = Some(new_access_token);
-            save_db(&db)?;
-        }
+                let folders: Vec<(String, String)> = folders
+                    .iter()
+                    .cloned()
+                    .map(|(id, name)| {
+                        Ok((id, crate::actions::decrypt(&name, None, None)?))
+                    })
+                    .collect::<anyhow::Result<_>>()?;
 
-        let folders: Vec<(String, String)> = folders
-            .iter()
-            .cloned()
-            .map(|(id, name)| {
-                Ok((id, crate::actions::decrypt(&name, None, None)?))
-            })
-            .collect::<anyhow::Result<_>>()?;
-
-        for (id, name) in folders {
-            if name == folder_name {
-                folder_id = Some(id);
+                for (id, name) in folders {
+                    if name == folder_name {
+                        folder_id = Some(id);
+                    }
+                }
+                if folder_id.is_none() {
+                    let (new_access_token, id) = rbw::actions::create_folder(
+                        &access_token,
+                        &refresh_token,
+                        &crate::actions::encrypt(folder_name, None, None)?,
+                    )?;
+                    if let Some(new_access_token) = new_access_token {
+                        access_token.clone_from(&new_access_token);
+                        db.access_token = Some(new_access_token);
+                        save_db(&db)?;
+                    }
+                    folder_id = Some(id);
+                }
             }
-        }
-        if folder_id.is_none() {
-            let (new_access_token, id) = rbw::actions::create_folder(
+
+            if let (Some(access_token), ()) = rbw::actions::add(
                 &access_token,
-                refresh_token,
-                &crate::actions::encrypt(folder_name, None, None)?,
-            )?;
-            if let Some(new_access_token) = new_access_token {
-                access_token.clone_from(&new_access_token);
-                db.access_token = Some(new_access_token);
+                &refresh_token,
+                &name,
+                &rbw::db::EntryData::Login {
+                    username,
+                    password,
+                    uris,
+                    totp: None,
+                },
+                notes.as_deref(),
+                folder_id.as_deref(),
+            )? {
+                db.access_token = Some(access_token);
                 save_db(&db)?;
             }
-            folder_id = Some(id);
-        }
-    }
 
-    if let (Some(access_token), ()) = rbw::actions::add(
-        &access_token,
-        refresh_token,
-        &name,
-        &rbw::db::EntryData::Login {
-            username,
-            password,
-            uris,
-            totp: None,
-        },
-        notes.as_deref(),
-        folder_id.as_deref(),
-    )? {
-        db.access_token = Some(access_token);
-        save_db(&db)?;
-    }
-
-    crate::actions::sync()?;
-
-    Ok(())
+            crate::actions::sync()?;
+            Ok(())
+        })(),
+    )
 }
 
 pub fn generate(
@@ -1824,7 +1833,7 @@ pub fn edit(
 
     let decrypted = decrypt_cipher(&entry)?;
 
-    let (data, fields, notes, history, unsaved) = match &decrypted.data {
+    match &decrypted.data {
         DecryptedData::Login { password, .. } => {
             let mut contents =
                 format!("{}\n", password.as_deref().unwrap_or(""));
@@ -1832,108 +1841,109 @@ pub fn edit(
                 write!(contents, "\n{notes}\n").unwrap();
             }
 
-            let contents = rbw::edit::edit(&contents, HELP_PW)?;
-            let unsaved = contents.clone();
-            let (password, notes) = parse_editor(&contents);
-            let password = password
-                .map(|password| {
-                    crate::actions::encrypt(
-                        &password,
-                        entry.key.as_deref(),
-                        entry.org_id.as_deref(),
-                    )
-                })
-                .transpose()?;
-            let notes = notes
-                .map(|notes| {
-                    crate::actions::encrypt(
-                        &notes,
-                        entry.key.as_deref(),
-                        entry.org_id.as_deref(),
-                    )
-                })
-                .transpose()?;
-            let mut history = entry.history.clone();
-            let rbw::db::EntryData::Login {
-                username: entry_username,
-                password: entry_password,
-                uris: entry_uris,
-                totp: entry_totp,
-            } = &entry.data
-            else {
-                unreachable!();
-            };
+            let (contents, source) =
+                rbw::edit::edit_from(&contents, HELP_PW)?;
+            after_editor(
+                source,
+                &contents,
+                (|| {
+                    let (password, notes) = parse_editor(&contents);
+                    let password = password
+                        .map(|password| {
+                            crate::actions::encrypt(
+                                &password,
+                                entry.key.as_deref(),
+                                entry.org_id.as_deref(),
+                            )
+                        })
+                        .transpose()?;
+                    let notes = notes
+                        .map(|notes| {
+                            crate::actions::encrypt(
+                                &notes,
+                                entry.key.as_deref(),
+                                entry.org_id.as_deref(),
+                            )
+                        })
+                        .transpose()?;
+                    let mut history = entry.history.clone();
+                    let rbw::db::EntryData::Login {
+                        username: entry_username,
+                        password: entry_password,
+                        uris: entry_uris,
+                        totp: entry_totp,
+                    } = &entry.data
+                    else {
+                        unreachable!();
+                    };
 
-            if let Some(prev_password) = entry_password.clone() {
-                let new_history_entry = rbw::db::HistoryEntry {
-                    last_used_date: format!(
-                        "{}",
-                        humantime::format_rfc3339(
-                            std::time::SystemTime::now()
-                        )
-                    ),
-                    password: prev_password,
-                };
-                history.insert(0, new_history_entry);
-            }
+                    if let Some(prev_password) = entry_password.clone() {
+                        let new_history_entry = rbw::db::HistoryEntry {
+                            last_used_date: format!(
+                                "{}",
+                                humantime::format_rfc3339(
+                                    std::time::SystemTime::now()
+                                )
+                            ),
+                            password: prev_password,
+                        };
+                        history.insert(0, new_history_entry);
+                    }
 
-            let data = rbw::db::EntryData::Login {
-                username: entry_username.clone(),
-                password,
-                uris: entry_uris.clone(),
-                totp: entry_totp.clone(),
-            };
-            (data, entry.fields.clone(), notes, history, unsaved)
+                    let data = rbw::db::EntryData::Login {
+                        username: entry_username.clone(),
+                        password,
+                        uris: entry_uris.clone(),
+                        totp: entry_totp.clone(),
+                    };
+                    put_cipher(
+                        &mut db,
+                        &entry,
+                        &data,
+                        &entry.fields,
+                        notes.as_deref(),
+                        &history,
+                    )
+                })(),
+            )
         }
         DecryptedData::SecureNote => {
-            let data = rbw::db::EntryData::SecureNote {};
-
             let editor_content = decrypted.notes.map_or_else(
                 || "\n".to_string(),
                 |notes| format!("{notes}\n"),
             );
-            let contents = rbw::edit::edit(&editor_content, HELP_NOTES)?;
-            let unsaved = contents.clone();
-
-            // prepend blank line to be parsed as pw by `parse_editor`
-            let (_, notes) = parse_editor(&format!("\n{contents}\n"));
-
-            let notes = notes
-                .map(|notes| {
-                    crate::actions::encrypt(
-                        &notes,
-                        entry.key.as_deref(),
-                        entry.org_id.as_deref(),
+            let (contents, source) =
+                rbw::edit::edit_from(&editor_content, HELP_NOTES)?;
+            after_editor(
+                source,
+                &contents,
+                (|| {
+                    // prepend blank line to be parsed as pw by `parse_editor`
+                    let (_, notes) = parse_editor(&format!("\n{contents}\n"));
+                    let notes = notes
+                        .map(|notes| {
+                            crate::actions::encrypt(
+                                &notes,
+                                entry.key.as_deref(),
+                                entry.org_id.as_deref(),
+                            )
+                        })
+                        .transpose()?;
+                    put_cipher(
+                        &mut db,
+                        &entry,
+                        &rbw::db::EntryData::SecureNote {},
+                        &entry.fields,
+                        notes.as_deref(),
+                        &entry.history,
                     )
-                })
-                .transpose()?;
-
-            (
-                data,
-                entry.fields.clone(),
-                notes,
-                entry.history.clone(),
-                unsaved,
+                })(),
             )
         }
-        _ => {
-            return Err(anyhow::anyhow!(
-                "modifications are only supported for login and note entries"
-            ));
-        }
-    };
-
-    if let Err(err) = put_cipher(
-        &mut db,
-        &entry,
-        &data,
-        &fields,
-        notes.as_deref(),
-        &history,
-    ) {
-        return Err(err_with_unsaved(err, &unsaved));
+        _ => Err(anyhow::anyhow!(
+            "modifications are only supported for login and note entries"
+        )),
     }
-    Ok(())
 }
 
 fn is_revision_conflict(err: &anyhow::Error) -> bool {
@@ -1943,10 +1953,23 @@ fn is_revision_conflict(err: &anyhow::Error) -> bool {
     )
 }
 
+fn persist_unsaved_after_edit(source: rbw::edit::Source) -> bool {
+    // Piped stdin never touched disk; writing unsaved-edits/ would
+    // change that. Interactive editor buffers live in a tempfile that
+    // disappears when this process returns, so those are worth keeping.
+    source == rbw::edit::Source::Editor
+}
+
 fn persist_unsaved_edit(buf: &str) -> anyhow::Result<std::path::PathBuf> {
+    persist_unsaved_edit_in(&rbw::dirs::unsaved_edit_dir(), buf)
+}
+
+fn persist_unsaved_edit_in(
+    dir: &std::path::Path,
+    buf: &str,
+) -> anyhow::Result<std::path::PathBuf> {
     use std::io::Write as _;
-    let dir = rbw::dirs::unsaved_edit_dir();
-    std::fs::create_dir_all(&dir)
+    rbw::dirs::create_dir_all_with_permissions(dir, 0o700)
         .with_context(|| format!("failed to create {}", dir.display()))?;
     let path = dir.join(format!(
         "unsaved-{}.txt",
@@ -1955,7 +1978,15 @@ fn persist_unsaved_edit(buf: &str) -> anyhow::Result<std::path::PathBuf> {
             .map(|d| d.as_nanos())
             .unwrap_or(0)
     ));
-    let mut file = std::fs::File::create(&path)
+    let mut opts = std::fs::OpenOptions::new();
+    opts.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        opts.mode(0o600);
+    }
+    let mut file = opts
+        .open(&path)
         .with_context(|| format!("failed to create {}", path.display()))?;
     #[cfg(unix)]
     {
@@ -1976,6 +2007,20 @@ fn err_with_unsaved(err: anyhow::Error, plaintext: &str) -> anyhow::Error {
         )),
         Err(stash_err) => err.context(stash_err),
     }
+}
+
+fn after_editor<T>(
+    source: rbw::edit::Source,
+    plaintext: &str,
+    result: anyhow::Result<T>,
+) -> anyhow::Result<T> {
+    result.map_err(|err| {
+        if persist_unsaved_after_edit(source) {
+            err_with_unsaved(err, plaintext)
+        } else {
+            err
+        }
+    })
 }
 
 fn put_cipher(
@@ -2007,19 +2052,14 @@ fn put_cipher(
         save_db(db)?;
     }
     // Agent rebuilds the master-password-reprompt ciphertext set only
-    // during sync. Patching the on-disk db is not enough: a following
-    // `rbw get` would decrypt the new hidden value without a prompt.
-    // The PUT already succeeded; a sync failure must not look like the
-    // edit itself failed.
-    if let Err(e) = crate::actions::sync() {
-        log::warn!(
-            "edit saved on the server, but local cache refresh failed: {e}"
-        );
-        eprintln!(
-            "edit saved on the server, but the local cache was not refreshed; run `rbw sync`"
-        );
-        return Ok(());
-    }
+    // during sync, and only after the new vault is on disk. A failed
+    // refresh here means disk and the in-memory set still match each
+    // other (both stale versus the server). Fail closed: the PUT
+    // succeeded, but this process cannot claim a consistent local view.
+    crate::actions::sync().context(
+        "edit saved on the server, but local cache refresh failed; \
+         run `rbw sync`",
+    )?;
     *db = load_db()?;
     Ok(())
 }
@@ -2128,7 +2168,7 @@ fn contains_help_body(text: &str) -> bool {
 fn read_custom_field_value(
     current: &str,
     ty: Option<rbw::api::FieldType>,
-) -> anyhow::Result<String> {
+) -> anyhow::Result<(String, rbw::edit::Source)> {
     let (start, end) = unique_help_markers(current);
     let help =
         field_help(ty == Some(rbw::api::FieldType::Boolean), &start, &end);
@@ -2139,21 +2179,24 @@ fn read_custom_field_value(
         let value = match source {
             rbw::edit::Source::Pipe => strip_trailing_newlines(&raw),
             rbw::edit::Source::Editor => {
-                strip_help_block(&raw, &start, &end)?
+                match strip_help_block(&raw, &start, &end) {
+                    Ok(value) => value,
+                    Err(e) => return Err(err_with_unsaved(e, &raw)),
+                }
             }
         };
         if value.is_empty() {
             anyhow::bail!("refusing to set an empty custom field value");
         }
         match validate_boolean_field(ty, &value) {
-            Ok(()) => return Ok(value),
+            Ok(()) => return Ok((value, source)),
             Err(e) if source == rbw::edit::Source::Editor => {
                 // Non-interactive $EDITOR that echoes the file (true,
                 // /bin/true) would loop forever if the stored value is
                 // already invalid.
                 attempts += 1;
                 if value == current || attempts >= 3 {
-                    return Err(e);
+                    return Err(err_with_unsaved(e, &value));
                 }
                 eprintln!("{e}; edit again");
                 current = value;
@@ -2181,8 +2224,8 @@ fn edit_custom_field(
     entry: &rbw::db::Entry,
     field_name: &str,
 ) -> anyhow::Result<()> {
-    // Client::edit has no SSH key PUT payload (unreachable!). Login,
-    // Secure Note, Card, and Identity all have typed PUT bodies.
+    // Client::edit_with_meta has no SSH key PUT payload (unreachable!).
+    // Login, Secure Note, Card, and Identity all have typed PUT bodies.
     if matches!(entry.data, rbw::db::EntryData::SshKey { .. }) {
         anyhow::bail!(
             "custom field edits are not supported for SSH key entries"
@@ -2195,14 +2238,18 @@ fn edit_custom_field(
     }
 
     let current = decrypt_custom_field_value(entry, idx)?;
-    let new_value = read_custom_field_value(&current, ty)?;
+    let (new_value, source) = read_custom_field_value(&current, ty)?;
     let original_ct = entry.fields[idx].value.clone();
-    put_field_plaintext(
-        db,
-        entry,
-        field_name,
+    after_editor(
+        source,
         &new_value,
-        original_ct.as_deref(),
+        put_field_plaintext(
+            db,
+            entry,
+            field_name,
+            &new_value,
+            original_ct.as_deref(),
+        ),
     )
 }
 
@@ -2277,20 +2324,16 @@ fn put_field_plaintext(
             if entry.fields[idx].value.as_deref() != original_ciphertext {
                 // Another client changed this same field. Rebase would
                 // use the new revision and silently overwrite them.
-                return Err(err_with_unsaved(
-                    err.context(
-                        "the same custom field was changed on the server",
-                    ),
-                    plaintext,
+                return Err(err.context(
+                    "the same custom field was changed on the server",
                 ));
             }
             validate_boolean_field(ty, plaintext)?;
             let (data, fields, notes, history) =
                 encrypt_named_field(&entry, field_name, plaintext)?;
             put_cipher(db, &entry, &data, &fields, notes.as_deref(), &history)
-                .map_err(|err| err_with_unsaved(err, plaintext))
         }
-        Err(err) => Err(err_with_unsaved(err, plaintext)),
+        Err(err) => Err(err),
     }
 }
 
@@ -2392,8 +2435,19 @@ pub fn purge() -> anyhow::Result<()> {
     stop_agent()?;
 
     remove_db()?;
+    remove_unsaved_edits()?;
 
     Ok(())
+}
+
+fn remove_unsaved_edits() -> anyhow::Result<()> {
+    let dir = rbw::dirs::unsaved_edit_dir();
+    match std::fs::remove_dir_all(&dir) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e)
+            .with_context(|| format!("failed to remove {}", dir.display())),
+    }
 }
 
 pub fn stop_agent() -> anyhow::Result<()> {
@@ -4797,5 +4851,43 @@ mod test {
             "anything"
         )
         .is_ok());
+    }
+
+    #[test]
+    fn test_persist_unsaved_after_edit_skips_pipe() {
+        assert!(!persist_unsaved_after_edit(rbw::edit::Source::Pipe));
+        assert!(persist_unsaved_after_edit(rbw::edit::Source::Editor));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_persist_unsaved_edit_permissions() {
+        use std::os::unix::fs::PermissionsExt as _;
+        let dir = tempfile::tempdir().unwrap();
+        let path =
+            persist_unsaved_edit_in(dir.path(), "secret-value").unwrap();
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "secret-value");
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+        assert_eq!(
+            std::fs::metadata(dir.path()).unwrap().permissions().mode()
+                & 0o777,
+            0o700
+        );
+    }
+
+    #[test]
+    fn test_after_editor_pipe_does_not_mention_stash() {
+        let err = after_editor::<()>(
+            rbw::edit::Source::Pipe,
+            "piped-secret",
+            Err(anyhow::anyhow!("put failed")),
+        )
+        .unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("put failed"));
+        assert!(!msg.contains("plaintext you just typed"));
     }
 }

--- a/src/bin/rbw/commands.rs
+++ b/src/bin/rbw/commands.rs
@@ -1227,17 +1227,18 @@ const HELP_NOTES: &str = r"
 # Lines with leading # will be ignored.
 ";
 
-const HELP_FIELD: &str = r"
-# The content of this file will be stored as the custom field value.
-# This help text is not saved.
-# Empty values are refused.
-";
+const HELP_START: &str = "# --- rbw field help start ---";
+const HELP_END: &str = "# --- rbw field help end ---";
 
-const HELP_FIELD_BOOLEAN: &str = r"
-# Enter true or false (nothing else).
-# This help text is not saved.
-# Empty values are refused.
-";
+fn field_help(boolean: bool) -> String {
+    let body = if boolean {
+        "# Enter true or false (nothing else).\n# Empty values are refused."
+    } else {
+        "# The content of this file will be stored as the custom field value.\n\
+         # Empty values are refused."
+    };
+    format!("\n{HELP_START}\n{body}\n{HELP_END}\n")
+}
 
 pub fn config_show() -> anyhow::Result<()> {
     let config = rbw::config::Config::load()?;
@@ -1789,9 +1790,15 @@ pub fn edit(
         name
     );
 
-    let (entry, decrypted) =
-        find_entry(&db, name, username, folder, ignore_case)
-            .with_context(|| format!("couldn't find entry for '{desc}'"))?;
+    let entry = find_db_entry(&db, name, username, folder, ignore_case)
+        .with_context(|| format!("couldn't find entry for '{desc}'"))?;
+    // Bitwarden has no single-field PATCH. A full PUT from a stale cache
+    // overwrites password/notes and, on a 1.15.0 cache, sends
+    // serde-default favorite=false. Sync first so the snapshot matches
+    // the server; lastKnownRevisionDate then rejects races while the
+    // editor is open. Do not sync again until after PUT.
+    let entry = refresh_entry(&mut db, &entry.id)?;
+    let decrypted = decrypt_cipher(&entry)?;
 
     if let Some(field_name) = field {
         edit_custom_field(&mut db, &entry, &decrypted, field_name)?;
@@ -1897,6 +1904,19 @@ pub fn edit(
     Ok(())
 }
 
+fn refresh_entry(
+    db: &mut rbw::db::Db,
+    id: &str,
+) -> anyhow::Result<rbw::db::Entry> {
+    crate::actions::sync()?;
+    *db = load_db()?;
+    db.entries
+        .iter()
+        .find(|entry| entry.id == id)
+        .cloned()
+        .ok_or_else(|| anyhow::anyhow!("entry disappeared after sync"))
+}
+
 fn put_cipher(
     db: &mut rbw::db::Db,
     entry: &rbw::db::Entry,
@@ -1905,6 +1925,7 @@ fn put_cipher(
     notes: Option<&str>,
     history: &[rbw::db::HistoryEntry],
 ) -> anyhow::Result<()> {
+    let meta = entry.cipher_write_meta();
     let access_token = db.access_token.as_ref().unwrap();
     let refresh_token = db.refresh_token.as_ref().unwrap();
     if let (Some(access_token), ()) = rbw::actions::edit(
@@ -1918,10 +1939,7 @@ fn put_cipher(
         notes,
         entry.folder_id.as_deref(),
         history,
-        entry.key.as_deref(),
-        entry.master_password_reprompt,
-        entry.favorite,
-        entry.archived_date.as_deref(),
+        &meta,
     )? {
         db.access_token = Some(access_token);
         save_db(db)?;
@@ -1971,42 +1989,67 @@ fn strip_trailing_newlines(s: &str) -> String {
     s.trim_end_matches(['\n', '\r']).to_string()
 }
 
-fn normalize_newlines(s: &str) -> String {
-    s.replace("\r\n", "\n").replace('\r', "\n")
+fn line_without_cr(line: &str) -> &str {
+    line.trim_end_matches('\r')
 }
 
-fn strip_help_block(raw: &str, help: &str) -> anyhow::Result<String> {
-    // Locate the appended help by content, not only as a suffix: the user
-    // may add lines after it, an editor may rewrite LF as CRLF, or they
-    // may delete the value and leave only the help. Saving the help text
-    // as the secret is worse than refusing.
-    let raw_n = normalize_newlines(raw);
-    let help_trim = normalize_newlines(help).trim_matches('\n').to_string();
-    let Some(idx) = raw_n.rfind(&help_trim) else {
-        if let Some(first) = help_trim.lines().next() {
-            if !first.is_empty() && raw_n.contains(first) {
-                anyhow::bail!(
-                    "editor output still contains the help text; \
-                     remove it or leave the help block intact"
-                );
-            }
-        }
-        return Ok(strip_trailing_newlines(&raw_n));
-    };
-    let before = raw_n[..idx]
-        .strip_suffix('\n')
-        .unwrap_or_else(|| &raw_n[..idx]);
-    let after_i = idx + help_trim.len();
-    let after = raw_n[after_i..]
-        .strip_prefix('\n')
-        .unwrap_or_else(|| &raw_n[after_i..]);
-    let combined = if before.is_empty() {
-        after.to_string()
-    } else if after.is_empty() {
-        before.to_string()
+fn help_residue_lines() -> impl Iterator<Item = &'static str> {
+    [
+        HELP_START,
+        HELP_END,
+        "# The content of this file will be stored as the custom field value.",
+        "# Enter true or false (nothing else).",
+        "# Empty values are refused.",
+    ]
+    .into_iter()
+}
+
+fn contains_help_residue(text: &str) -> bool {
+    text.lines().any(|line| {
+        let line = line_without_cr(line);
+        help_residue_lines().any(|help| line == help)
+    })
+}
+
+fn marker_span_start(raw: &str, marker_at: usize) -> usize {
+    if marker_at >= 2
+        && raw.as_bytes()[marker_at - 2] == b'\r'
+        && raw.as_bytes()[marker_at - 1] == b'\n'
+    {
+        marker_at - 2
+    } else if marker_at >= 1 && raw.as_bytes()[marker_at - 1] == b'\n' {
+        marker_at - 1
     } else {
-        format!("{before}\n{after}")
+        marker_at
+    }
+}
+
+fn strip_help_block(raw: &str) -> anyhow::Result<String> {
+    // Explicit start/end markers so we can delete the stub without
+    // rewriting the user's newlines. Matching on help prose as a suffix
+    // either ate `#` lines or, when the suffix failed, saved the stub.
+    // Consume the newline *before* START (inserted with the stub) but
+    // leave the newline after END so following user lines stay separate.
+    let start = raw.find(HELP_START);
+    let end = raw.find(HELP_END);
+    let combined = match (start, end) {
+        (Some(s), Some(e)) if e > s => {
+            let from = marker_span_start(raw, s);
+            let to = e + HELP_END.len();
+            format!("{}{}", &raw[..from], &raw[to..])
+        }
+        (None, None) => raw.to_string(),
+        _ => anyhow::bail!(
+            "unbalanced help markers; leave the rbw help block intact \
+             or remove it entirely"
+        ),
     };
+    if contains_help_residue(&combined) {
+        anyhow::bail!(
+            "editor output still contains the help text; \
+             remove it or leave the help block intact"
+        );
+    }
     Ok(strip_trailing_newlines(&combined))
 }
 
@@ -2014,17 +2057,14 @@ fn read_custom_field_value(
     current: &str,
     ty: Option<rbw::api::FieldType>,
 ) -> anyhow::Result<String> {
-    let help = if ty == Some(rbw::api::FieldType::Boolean) {
-        HELP_FIELD_BOOLEAN
-    } else {
-        HELP_FIELD
-    };
+    let help = field_help(ty == Some(rbw::api::FieldType::Boolean));
     let mut current = current.to_string();
+    let mut attempts = 0_u8;
     loop {
-        let (raw, source) = rbw::edit::edit_from(&current, help)?;
+        let (raw, source) = rbw::edit::edit_from(&current, &help)?;
         let value = match source {
             rbw::edit::Source::Pipe => strip_trailing_newlines(&raw),
-            rbw::edit::Source::Editor => strip_help_block(&raw, help)?,
+            rbw::edit::Source::Editor => strip_help_block(&raw)?,
         };
         if value.is_empty() {
             anyhow::bail!("refusing to set an empty custom field value");
@@ -2032,6 +2072,13 @@ fn read_custom_field_value(
         match validate_boolean_field(ty, &value) {
             Ok(()) => return Ok(value),
             Err(e) if source == rbw::edit::Source::Editor => {
+                // Non-interactive $EDITOR that echoes the file (true,
+                // /bin/true) would loop forever if the stored value is
+                // already invalid.
+                attempts += 1;
+                if value == current || attempts >= 3 {
+                    return Err(e);
+                }
                 eprintln!("{e}; edit again");
                 current = value;
             }
@@ -2273,6 +2320,9 @@ fn find_db_entry(
 fn print_editable_custom_field_names(
     entry: &rbw::db::Entry,
 ) -> anyhow::Result<()> {
+    if matches!(entry.data, rbw::db::EntryData::SshKey { .. }) {
+        anyhow::bail!("SSH key entries have no editable custom fields");
+    }
     for field in &entry.fields {
         if field.ty == Some(rbw::api::FieldType::Linked) {
             continue;
@@ -4409,6 +4459,7 @@ mod test {
                 master_password_reprompt: rbw::api::CipherRepromptType::None,
                 favorite: false,
                 archived_date: None,
+                revision_date: None,
             },
             DecryptedSearchCipher {
                 id: id.to_string(),
@@ -4473,32 +4524,27 @@ mod test {
 
     #[test]
     fn test_strip_help_block() {
-        let contents = format!("value\n#keep{HELP_FIELD}");
-        assert_eq!(
-            strip_help_block(&contents, HELP_FIELD).unwrap(),
-            "value\n#keep"
-        );
-        let crlf =
-            format!("value\r\n#keep{}", HELP_FIELD.replace('\n', "\r\n"));
-        assert_eq!(
-            strip_help_block(&crlf, HELP_FIELD).unwrap(),
-            "value\n#keep"
-        );
-        let after = format!("value{HELP_FIELD}# mine\n");
-        assert_eq!(
-            strip_help_block(&after, HELP_FIELD).unwrap(),
-            "value\n# mine"
-        );
-        // User deleted the value line and left only the help: empty, so
-        // read_custom_field_value will refuse rather than save the stub.
-        assert_eq!(strip_help_block(HELP_FIELD, HELP_FIELD).unwrap(), "");
-        let leftover =
-            format!("value\n{}", HELP_FIELD.lines().nth(1).unwrap());
-        assert!(strip_help_block(&leftover, HELP_FIELD).is_err());
-        assert_eq!(
-            strip_help_block("just-piped\n", HELP_FIELD).unwrap(),
-            "just-piped"
-        );
+        let help = field_help(false);
+        let contents = format!("value\n#keep{help}");
+        assert_eq!(strip_help_block(&contents).unwrap(), "value\n#keep");
+
+        let crlf = format!("value\r\n#keep{}", help.replace('\n', "\r\n"));
+        assert_eq!(strip_help_block(&crlf).unwrap(), "value\r\n#keep");
+
+        let after = format!("value{help}# mine\n");
+        assert_eq!(strip_help_block(&after).unwrap(), "value\n# mine");
+
+        assert_eq!(strip_help_block(&help).unwrap(), "");
+        assert_eq!(strip_help_block("just-piped\n").unwrap(), "just-piped");
+
+        let crlf_value = format!("a\r\nb{help}");
+        assert_eq!(strip_help_block(&crlf_value).unwrap(), "a\r\nb");
+
+        let leftover_end = format!("value\n{HELP_END}\n");
+        assert!(strip_help_block(&leftover_end).is_err());
+        let leftover_body =
+            "value\n# Empty values are refused.\n".to_string();
+        assert!(strip_help_block(&leftover_body).is_err());
     }
 
     #[test]

--- a/src/bin/rbw/commands.rs
+++ b/src/bin/rbw/commands.rs
@@ -1931,14 +1931,7 @@ pub fn edit(
         notes.as_deref(),
         &history,
     ) {
-        if is_revision_conflict(&err) {
-            let path = persist_unsaved_edit(&unsaved)?;
-            return Err(err).context(format!(
-                "unsaved edit written to {}",
-                path.display()
-            ));
-        }
-        return Err(err);
+        return Err(err_with_unsaved(err, &unsaved));
     }
     Ok(())
 }
@@ -1952,14 +1945,37 @@ fn is_revision_conflict(err: &anyhow::Error) -> bool {
 
 fn persist_unsaved_edit(buf: &str) -> anyhow::Result<std::path::PathBuf> {
     use std::io::Write as _;
-    let mut tmp = tempfile::NamedTempFile::new()
-        .context("failed to create unsaved-edit tempfile")?;
-    tmp.write_all(buf.as_bytes())
-        .context("failed to write unsaved-edit tempfile")?;
-    let (_, path) = tmp.keep().map_err(|e| {
-        anyhow::anyhow!("failed to persist unsaved edit: {e}")
-    })?;
+    let dir = rbw::dirs::unsaved_edit_dir();
+    std::fs::create_dir_all(&dir)
+        .with_context(|| format!("failed to create {}", dir.display()))?;
+    let path = dir.join(format!(
+        "unsaved-{}.txt",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    ));
+    let mut file = std::fs::File::create(&path)
+        .with_context(|| format!("failed to create {}", path.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        file.set_permissions(std::fs::Permissions::from_mode(0o600))
+            .context("failed to chmod unsaved-edit file")?;
+    }
+    file.write_all(buf.as_bytes())
+        .context("failed to write unsaved-edit file")?;
     Ok(path)
+}
+
+fn err_with_unsaved(err: anyhow::Error, plaintext: &str) -> anyhow::Error {
+    match persist_unsaved_edit(plaintext) {
+        Ok(path) => err.context(format!(
+            "plaintext you just typed is in {} — delete that file after recovering",
+            path.display()
+        )),
+        Err(stash_err) => err.context(stash_err),
+    }
 }
 
 fn put_cipher(
@@ -1973,7 +1989,7 @@ fn put_cipher(
     let meta = entry.cipher_write_meta();
     let access_token = db.access_token.as_ref().unwrap();
     let refresh_token = db.refresh_token.as_ref().unwrap();
-    let (new_token, ()) = rbw::actions::edit(
+    let (new_token, ()) = rbw::actions::edit_with_meta(
         access_token,
         refresh_token,
         &entry.id,
@@ -1993,7 +2009,17 @@ fn put_cipher(
     // Agent rebuilds the master-password-reprompt ciphertext set only
     // during sync. Patching the on-disk db is not enough: a following
     // `rbw get` would decrypt the new hidden value without a prompt.
-    crate::actions::sync()?;
+    // The PUT already succeeded; a sync failure must not look like the
+    // edit itself failed.
+    if let Err(e) = crate::actions::sync() {
+        log::warn!(
+            "edit saved on the server, but local cache refresh failed: {e}"
+        );
+        eprintln!(
+            "edit saved on the server, but the local cache was not refreshed; run `rbw sync`"
+        );
+        return Ok(());
+    }
     *db = load_db()?;
     Ok(())
 }
@@ -2251,16 +2277,20 @@ fn put_field_plaintext(
             if entry.fields[idx].value.as_deref() != original_ciphertext {
                 // Another client changed this same field. Rebase would
                 // use the new revision and silently overwrite them.
-                return Err(err).context(
-                    "the same custom field was changed on the server",
-                );
+                return Err(err_with_unsaved(
+                    err.context(
+                        "the same custom field was changed on the server",
+                    ),
+                    plaintext,
+                ));
             }
             validate_boolean_field(ty, plaintext)?;
             let (data, fields, notes, history) =
                 encrypt_named_field(&entry, field_name, plaintext)?;
             put_cipher(db, &entry, &data, &fields, notes.as_deref(), &history)
+                .map_err(|err| err_with_unsaved(err, plaintext))
         }
-        Err(err) => Err(err),
+        Err(err) => Err(err_with_unsaved(err, plaintext)),
     }
 }
 
@@ -4725,6 +4755,18 @@ mod test {
         assert!(strip_help_block(&end_before_start, start, end).is_err());
         let leftover_body = format!("value\n{HELP_BODY}\n");
         assert!(strip_help_block(&leftover_body, start, end).is_err());
+    }
+
+    #[test]
+    fn test_unique_help_markers_avoid_existing_fence() {
+        let stale_start = "# --- rbw field help start OLDNONCE ---";
+        let stale_end = "# --- rbw field help end OLDNONCE ---";
+        let current = format!("keep {stale_start} {stale_end} keep");
+        let (start, end) = unique_help_markers(&current);
+        assert_ne!(start, stale_start);
+        assert_ne!(end, stale_end);
+        assert!(!current.contains(&start));
+        assert!(!current.contains(&end));
     }
 
     #[test]

--- a/src/bin/rbw/commands.rs
+++ b/src/bin/rbw/commands.rs
@@ -1,7 +1,6 @@
 use std::{fmt::Write as _, io::Write as _, os::unix::ffi::OsStrExt as _};
 
 use anyhow::Context as _;
-use is_terminal::IsTerminal as _;
 
 // The default number of seconds the generated TOTP
 // code lasts for before a new one must be generated
@@ -995,6 +994,14 @@ impl DecryptedCipher {
         }
     }
 
+    fn display_custom_fields_list(&self) {
+        for f in &self.fields {
+            if let Some(name) = &f.name {
+                println!("{name}");
+            }
+        }
+    }
+
     fn display_json(&self, desc: &str) -> anyhow::Result<()> {
         serde_json::to_writer_pretty(std::io::stdout(), &self)
             .context(format!("failed to write entry '{desc}' to stdout"))?;
@@ -1231,6 +1238,7 @@ const HELP_NOTES: &str = r"
 const HELP_FIELD: &str = r"
 # The content of this file will be stored as the custom field value.
 # This help text is not saved.
+# Empty values are refused.
 ";
 
 pub fn config_show() -> anyhow::Result<()> {
@@ -1400,6 +1408,7 @@ pub fn get(
     clipboard: bool,
     ignore_case: bool,
     list_fields: bool,
+    list_custom_fields: bool,
 ) -> anyhow::Result<()> {
     unlock()?;
 
@@ -1414,7 +1423,9 @@ pub fn get(
     let (_, decrypted) =
         find_entry(&db, needle, user, folder, ignore_case)
             .with_context(|| format!("couldn't find entry for '{desc}'"))?;
-    if list_fields {
+    if list_custom_fields {
+        decrypted.display_custom_fields_list();
+    } else if list_fields {
         decrypted.display_fields_list();
     } else if raw {
         decrypted.display_json(&desc)?;
@@ -1959,12 +1970,10 @@ fn strip_appended_help(raw: &str, help: &str) -> String {
 }
 
 fn read_custom_field_value(current: &str) -> anyhow::Result<String> {
-    let piped = !std::io::stdin().is_terminal();
-    let raw = rbw::edit::edit(current, HELP_FIELD)?;
-    let value = if piped {
-        strip_trailing_newlines(&raw)
-    } else {
-        strip_appended_help(&raw, HELP_FIELD)
+    let (raw, source) = rbw::edit::edit_from(current, HELP_FIELD)?;
+    let value = match source {
+        rbw::edit::Source::Pipe => strip_trailing_newlines(&raw),
+        rbw::edit::Source::Editor => strip_appended_help(&raw, HELP_FIELD),
     };
     if value.is_empty() {
         anyhow::bail!("refusing to set an empty custom field value");

--- a/src/bin/rbw/commands.rs
+++ b/src/bin/rbw/commands.rs
@@ -1708,14 +1708,7 @@ fn add_after_editor(
         notes.as_deref(),
         folder_id.as_deref(),
     )?;
-    after_server_write(|| {
-        if let Some(new_token) = new_token {
-            db.access_token = Some(new_token);
-            save_db(db)?;
-        }
-        crate::actions::sync()?;
-        Ok(())
-    })
+    after_server_write(db, new_token)
 }
 
 pub fn generate(
@@ -1804,14 +1797,7 @@ pub fn generate(
             None,
             folder_id.as_deref(),
         )?;
-        after_server_write(|| {
-            if let Some(new_token) = new_token {
-                db.access_token = Some(new_token);
-                save_db(&db)?;
-            }
-            crate::actions::sync()?;
-            Ok(())
-        })?;
+        after_server_write(&mut db, new_token)?;
     }
 
     Ok(())
@@ -2064,10 +2050,21 @@ impl std::fmt::Display for LocalCacheRefreshFailed {
 
 impl std::error::Error for LocalCacheRefreshFailed {}
 
-fn after_server_write<T>(
-    op: impl FnOnce() -> anyhow::Result<T>,
-) -> anyhow::Result<T> {
-    op().context(LocalCacheRefreshFailed)
+/// Persist local state after `add` / `edit_with_meta` already returned
+/// Ok. `new_token` is that Ok value's optional refreshed access token,
+/// so the call site has to have completed the server write first.
+/// Token save, vault sync, and db reload are exit 2 on failure.
+fn after_server_write(
+    db: &mut rbw::db::Db,
+    new_token: Option<String>,
+) -> anyhow::Result<()> {
+    if let Some(new_token) = new_token {
+        db.access_token = Some(new_token);
+        save_db(db).context(LocalCacheRefreshFailed)?;
+    }
+    crate::actions::sync().context(LocalCacheRefreshFailed)?;
+    *db = load_db().context(LocalCacheRefreshFailed)?;
+    Ok(())
 }
 
 fn is_local_cache_refresh_failed(err: &anyhow::Error) -> bool {
@@ -2113,15 +2110,7 @@ fn put_cipher(
     // during sync, and only after the new vault is on disk. Any local
     // failure after the PUT (token save, sync, reload) is exit 2: the
     // server write landed; callers must not retry it.
-    after_server_write(|| {
-        if let Some(new_token) = new_token {
-            db.access_token = Some(new_token);
-            save_db(db)?;
-        }
-        crate::actions::sync()?;
-        *db = load_db()?;
-        Ok(())
-    })
+    after_server_write(db, new_token)
 }
 
 fn find_custom_field_index(
@@ -4997,18 +4986,6 @@ mod test {
         assert!(msg.contains("put failed"));
         assert!(msg.contains("the piped value was not written to disk"));
         assert!(!msg.contains("plaintext you just typed"));
-    }
-
-    #[test]
-    fn test_after_server_write_marks_exit_2() {
-        let err = after_server_write(|| {
-            Err::<(), _>(anyhow::anyhow!("save_db failed"))
-        })
-        .unwrap_err();
-        assert_eq!(exit_status(&err), 2);
-        let msg = format!("{err:#}");
-        assert!(msg.contains("save_db failed"));
-        assert!(msg.contains("do not retry the write"));
     }
 
     #[test]

--- a/src/bin/rbw/commands.rs
+++ b/src/bin/rbw/commands.rs
@@ -1,6 +1,7 @@
 use std::{fmt::Write as _, io::Write as _, os::unix::ffi::OsStrExt as _};
 
 use anyhow::Context as _;
+use is_terminal::IsTerminal as _;
 
 // The default number of seconds the generated TOTP
 // code lasts for before a new one must be generated
@@ -1227,6 +1228,11 @@ const HELP_NOTES: &str = r"
 # Lines with leading # will be ignored.
 ";
 
+const HELP_FIELD: &str = r"
+# The content of this file will be stored as the custom field value.
+# Lines with leading # will be ignored.
+";
+
 pub fn config_show() -> anyhow::Result<()> {
     let config = rbw::config::Config::load()?;
     serde_json::to_writer_pretty(std::io::stdout(), &config)
@@ -1755,12 +1761,11 @@ pub fn edit(
     username: Option<&str>,
     folder: Option<&str>,
     ignore_case: bool,
+    field: Option<&str>,
 ) -> anyhow::Result<()> {
     unlock()?;
 
     let mut db = load_db()?;
-    let access_token = db.access_token.as_ref().unwrap();
-    let refresh_token = db.refresh_token.as_ref().unwrap();
 
     let desc = format!(
         "{}{}",
@@ -1771,6 +1776,15 @@ pub fn edit(
     let (entry, decrypted) =
         find_entry(&db, name, username, folder, ignore_case)
             .with_context(|| format!("couldn't find entry for '{desc}'"))?;
+
+    if let Some(field_name) = field {
+        edit_custom_field(&mut db, &entry, &decrypted, field_name)?;
+        crate::actions::sync()?;
+        return Ok(());
+    }
+
+    let access_token = db.access_token.as_ref().unwrap();
+    let refresh_token = db.refresh_token.as_ref().unwrap();
 
     let (data, fields, notes, history) = match &decrypted.data {
         DecryptedData::Login { password, .. } => {
@@ -1872,6 +1886,104 @@ pub fn edit(
     }
 
     crate::actions::sync()?;
+    Ok(())
+}
+
+fn find_custom_field_index(
+    fields: &[DecryptedField],
+    name: &str,
+) -> anyhow::Result<usize> {
+    let exact: Vec<usize> = fields
+        .iter()
+        .enumerate()
+        .filter_map(|(i, field)| {
+            field.name.as_deref().filter(|n| *n == name).map(|_| i)
+        })
+        .collect();
+    match exact.len() {
+        1 => return Ok(exact[0]),
+        n if n > 1 => {
+            anyhow::bail!("multiple custom fields named '{name}'")
+        }
+        _ => {}
+    }
+
+    let lower = name.to_lowercase();
+    let case_insensitive: Vec<usize> = fields
+        .iter()
+        .enumerate()
+        .filter_map(|(i, field)| {
+            field
+                .name
+                .as_deref()
+                .filter(|n| n.to_lowercase() == lower)
+                .map(|_| i)
+        })
+        .collect();
+    match case_insensitive.len() {
+        1 => Ok(case_insensitive[0]),
+        0 => anyhow::bail!("no custom field named '{name}'"),
+        _ => anyhow::bail!("multiple custom fields matching '{name}'"),
+    }
+}
+
+fn strip_trailing_newlines(s: &str) -> String {
+    s.trim_end_matches(['\n', '\r']).to_string()
+}
+
+fn strip_comment_lines(s: &str) -> String {
+    s.lines()
+        .filter(|line| !line.starts_with('#'))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn read_custom_field_value(current: &str) -> anyhow::Result<String> {
+    let piped = !std::io::stdin().is_terminal();
+    let raw = rbw::edit::edit(current, HELP_FIELD)?;
+    let value = if piped {
+        strip_trailing_newlines(&raw)
+    } else {
+        strip_trailing_newlines(&strip_comment_lines(&raw))
+    };
+    if value.is_empty() {
+        anyhow::bail!("refusing to set an empty custom field value");
+    }
+    Ok(value)
+}
+
+fn edit_custom_field(
+    db: &mut rbw::db::Db,
+    entry: &rbw::db::Entry,
+    decrypted: &DecryptedCipher,
+    field_name: &str,
+) -> anyhow::Result<()> {
+    let idx = find_custom_field_index(&decrypted.fields, field_name)?;
+    let current = decrypted.fields[idx].value.clone().unwrap_or_default();
+    let new_value = read_custom_field_value(&current)?;
+    let encrypted =
+        crate::actions::encrypt(&new_value, entry.org_id.as_deref())?;
+
+    let mut fields = entry.fields.clone();
+    fields[idx].value = Some(encrypted);
+
+    let access_token = db.access_token.as_ref().unwrap();
+    let refresh_token = db.refresh_token.as_ref().unwrap();
+    if let (Some(access_token), ()) = rbw::actions::edit(
+        access_token,
+        refresh_token,
+        &entry.id,
+        entry.org_id.as_deref(),
+        &entry.name,
+        &entry.data,
+        &fields,
+        entry.notes.as_deref(),
+        entry.folder_id.as_deref(),
+        &entry.history,
+    )? {
+        db.access_token = Some(access_token);
+        save_db(db)?;
+    }
     Ok(())
 }
 
@@ -4174,5 +4286,54 @@ mod test {
                 notes: None,
             },
         )
+    }
+
+    fn custom_field(name: &str) -> DecryptedField {
+        DecryptedField {
+            name: Some(name.to_string()),
+            value: Some("v".to_string()),
+            ty: Some(rbw::api::FieldType::Hidden),
+        }
+    }
+
+    #[test]
+    fn test_find_custom_field_index() {
+        let fields = vec![
+            custom_field("GITHUB_CONTENT_TOKEN"),
+            custom_field("GITHUB_ISSUE_TOKEN"),
+        ];
+        assert_eq!(
+            find_custom_field_index(&fields, "GITHUB_CONTENT_TOKEN").unwrap(),
+            0
+        );
+        assert_eq!(
+            find_custom_field_index(&fields, "github_issue_token").unwrap(),
+            1
+        );
+        assert!(find_custom_field_index(&fields, "missing").is_err());
+    }
+
+    #[test]
+    fn test_find_custom_field_index_duplicates() {
+        let fields = vec![custom_field("FOO"), custom_field("FOO")];
+        assert!(find_custom_field_index(&fields, "FOO").is_err());
+        let fields = vec![custom_field("FOO"), custom_field("foo")];
+        assert_eq!(find_custom_field_index(&fields, "FOO").unwrap(), 0);
+        assert_eq!(find_custom_field_index(&fields, "foo").unwrap(), 1);
+        assert!(find_custom_field_index(&fields, "FoO").is_err());
+    }
+
+    #[test]
+    fn test_strip_trailing_newlines() {
+        assert_eq!(strip_trailing_newlines("abc\n"), "abc");
+        assert_eq!(strip_trailing_newlines("abc\r\n"), "abc");
+        assert_eq!(strip_trailing_newlines("abc"), "abc");
+        assert_eq!(strip_trailing_newlines("a\nbc\n"), "a\nbc");
+    }
+
+    #[test]
+    fn test_strip_comment_lines() {
+        assert_eq!(strip_comment_lines("secret\n# ignored\n"), "secret");
+        assert_eq!(strip_comment_lines("# only comments\n"), "");
     }
 }

--- a/src/bin/rbw/commands.rs
+++ b/src/bin/rbw/commands.rs
@@ -994,14 +994,6 @@ impl DecryptedCipher {
         }
     }
 
-    fn display_custom_fields_list(&self) {
-        for f in &self.fields {
-            if let Some(name) = &f.name {
-                println!("{name}");
-            }
-        }
-    }
-
     fn display_json(&self, desc: &str) -> anyhow::Result<()> {
         serde_json::to_writer_pretty(std::io::stdout(), &self)
             .context(format!("failed to write entry '{desc}' to stdout"))?;
@@ -1241,6 +1233,12 @@ const HELP_FIELD: &str = r"
 # Empty values are refused.
 ";
 
+const HELP_FIELD_BOOLEAN: &str = r"
+# Enter true or false (nothing else).
+# This help text is not saved.
+# Empty values are refused.
+";
+
 pub fn config_show() -> anyhow::Result<()> {
     let config = rbw::config::Config::load()?;
     serde_json::to_writer_pretty(std::io::stdout(), &config)
@@ -1420,12 +1418,19 @@ pub fn get(
         needle
     );
 
+    if list_custom_fields {
+        // Names only: decrypting hidden *values* would master-password
+        // reprompt, which is hostile for fish `edit --field` completion.
+        let entry = find_db_entry(&db, needle, user, folder, ignore_case)
+            .with_context(|| format!("couldn't find entry for '{desc}'"))?;
+        print_editable_custom_field_names(&entry)?;
+        return Ok(());
+    }
+
     let (_, decrypted) =
         find_entry(&db, needle, user, folder, ignore_case)
             .with_context(|| format!("couldn't find entry for '{desc}'"))?;
-    if list_custom_fields {
-        decrypted.display_custom_fields_list();
-    } else if list_fields {
+    if list_fields {
         decrypted.display_fields_list();
     } else if raw {
         decrypted.display_json(&desc)?;
@@ -1794,9 +1799,6 @@ pub fn edit(
         return Ok(());
     }
 
-    let access_token = db.access_token.as_ref().unwrap();
-    let refresh_token = db.refresh_token.as_ref().unwrap();
-
     let (data, fields, notes, history) = match &decrypted.data {
         DecryptedData::Login { password, .. } => {
             let mut contents =
@@ -1856,7 +1858,7 @@ pub fn edit(
                 uris: entry_uris.clone(),
                 totp: entry_totp.clone(),
             };
-            (data, entry.fields, notes, history)
+            (data, entry.fields.clone(), notes, history)
         }
         DecryptedData::SecureNote => {
             let data = rbw::db::EntryData::SecureNote {};
@@ -1880,7 +1882,7 @@ pub fn edit(
                 })
                 .transpose()?;
 
-            (data, entry.fields, notes, entry.history)
+            (data, entry.fields.clone(), notes, entry.history.clone())
         }
         _ => {
             return Err(anyhow::anyhow!(
@@ -1889,24 +1891,41 @@ pub fn edit(
         }
     };
 
+    put_cipher(&mut db, &entry, &data, &fields, notes.as_deref(), &history)?;
+
+    crate::actions::sync()?;
+    Ok(())
+}
+
+fn put_cipher(
+    db: &mut rbw::db::Db,
+    entry: &rbw::db::Entry,
+    data: &rbw::db::EntryData,
+    fields: &[rbw::db::Field],
+    notes: Option<&str>,
+    history: &[rbw::db::HistoryEntry],
+) -> anyhow::Result<()> {
+    let access_token = db.access_token.as_ref().unwrap();
+    let refresh_token = db.refresh_token.as_ref().unwrap();
     if let (Some(access_token), ()) = rbw::actions::edit(
         access_token,
         refresh_token,
         &entry.id,
         entry.org_id.as_deref(),
         &entry.name,
-        &data,
-        &fields,
-        notes.as_deref(),
+        data,
+        fields,
+        notes,
         entry.folder_id.as_deref(),
-        &history,
+        history,
         entry.key.as_deref(),
+        entry.master_password_reprompt,
+        entry.favorite,
+        entry.archived_date.as_deref(),
     )? {
         db.access_token = Some(access_token);
-        save_db(&db)?;
+        save_db(db)?;
     }
-
-    crate::actions::sync()?;
     Ok(())
 }
 
@@ -1952,51 +1971,86 @@ fn strip_trailing_newlines(s: &str) -> String {
     s.trim_end_matches(['\n', '\r']).to_string()
 }
 
-fn strip_appended_help(raw: &str, help: &str) -> String {
-    let help_trim = help.trim_end_matches(['\n', '\r']);
-    let mut s = raw;
-    if let Some(prefix) = s.strip_suffix(help) {
-        s = prefix;
-    } else if let Some(without_nl) = s.strip_suffix('\n') {
-        if let Some(prefix) = without_nl.strip_suffix(help) {
-            s = prefix;
-        } else if let Some(prefix) = without_nl.strip_suffix(help_trim) {
-            s = prefix;
+fn normalize_newlines(s: &str) -> String {
+    s.replace("\r\n", "\n").replace('\r', "\n")
+}
+
+fn strip_help_block(raw: &str, help: &str) -> anyhow::Result<String> {
+    // Locate the appended help by content, not only as a suffix: the user
+    // may add lines after it, an editor may rewrite LF as CRLF, or they
+    // may delete the value and leave only the help. Saving the help text
+    // as the secret is worse than refusing.
+    let raw_n = normalize_newlines(raw);
+    let help_trim = normalize_newlines(help).trim_matches('\n').to_string();
+    let Some(idx) = raw_n.rfind(&help_trim) else {
+        if let Some(first) = help_trim.lines().next() {
+            if !first.is_empty() && raw_n.contains(first) {
+                anyhow::bail!(
+                    "editor output still contains the help text; \
+                     remove it or leave the help block intact"
+                );
+            }
         }
-    } else if let Some(prefix) = s.strip_suffix(help_trim) {
-        s = prefix;
-    }
-    strip_trailing_newlines(s)
-}
-
-fn read_custom_field_value(current: &str) -> anyhow::Result<String> {
-    let (raw, source) = rbw::edit::edit_from(current, HELP_FIELD)?;
-    let value = match source {
-        rbw::edit::Source::Pipe => strip_trailing_newlines(&raw),
-        rbw::edit::Source::Editor => strip_appended_help(&raw, HELP_FIELD),
+        return Ok(strip_trailing_newlines(&raw_n));
     };
-    if value.is_empty() {
-        anyhow::bail!("refusing to set an empty custom field value");
-    }
-    Ok(value)
+    let before = raw_n[..idx]
+        .strip_suffix('\n')
+        .unwrap_or_else(|| &raw_n[..idx]);
+    let after_i = idx + help_trim.len();
+    let after = raw_n[after_i..]
+        .strip_prefix('\n')
+        .unwrap_or_else(|| &raw_n[after_i..]);
+    let combined = if before.is_empty() {
+        after.to_string()
+    } else if after.is_empty() {
+        before.to_string()
+    } else {
+        format!("{before}\n{after}")
+    };
+    Ok(strip_trailing_newlines(&combined))
 }
 
-fn validate_custom_field_value(
+fn read_custom_field_value(
+    current: &str,
+    ty: Option<rbw::api::FieldType>,
+) -> anyhow::Result<String> {
+    let help = if ty == Some(rbw::api::FieldType::Boolean) {
+        HELP_FIELD_BOOLEAN
+    } else {
+        HELP_FIELD
+    };
+    let mut current = current.to_string();
+    loop {
+        let (raw, source) = rbw::edit::edit_from(&current, help)?;
+        let value = match source {
+            rbw::edit::Source::Pipe => strip_trailing_newlines(&raw),
+            rbw::edit::Source::Editor => strip_help_block(&raw, help)?,
+        };
+        if value.is_empty() {
+            anyhow::bail!("refusing to set an empty custom field value");
+        }
+        match validate_boolean_field(ty, &value) {
+            Ok(()) => return Ok(value),
+            Err(e) if source == rbw::edit::Source::Editor => {
+                eprintln!("{e}; edit again");
+                current = value;
+            }
+            Err(e) => return Err(e),
+        }
+    }
+}
+
+fn validate_boolean_field(
     ty: Option<rbw::api::FieldType>,
     value: &str,
 ) -> anyhow::Result<()> {
-    match ty {
-        Some(rbw::api::FieldType::Linked) => {
-            anyhow::bail!("linked custom fields cannot be edited as values")
-        }
-        Some(rbw::api::FieldType::Boolean) => {
-            if value != "true" && value != "false" {
-                anyhow::bail!("boolean custom fields must be true or false");
-            }
-            Ok(())
-        }
-        _ => Ok(()),
+    if ty == Some(rbw::api::FieldType::Boolean)
+        && value != "true"
+        && value != "false"
+    {
+        anyhow::bail!("boolean custom fields must be true or false");
     }
+    Ok(())
 }
 
 fn edit_custom_field(
@@ -2005,6 +2059,8 @@ fn edit_custom_field(
     decrypted: &DecryptedCipher,
     field_name: &str,
 ) -> anyhow::Result<()> {
+    // Client::edit has no SSH key PUT payload (unreachable!). Login,
+    // Secure Note, Card, and Identity all have typed PUT bodies.
     if matches!(decrypted.data, DecryptedData::SshKey { .. }) {
         anyhow::bail!(
             "custom field edits are not supported for SSH key entries"
@@ -2018,8 +2074,7 @@ fn edit_custom_field(
     }
 
     let current = field.value.clone().unwrap_or_default();
-    let new_value = read_custom_field_value(&current)?;
-    validate_custom_field_value(field.ty, &new_value)?;
+    let new_value = read_custom_field_value(&current, field.ty)?;
     let encrypted = crate::actions::encrypt(
         &new_value,
         entry.key.as_deref(),
@@ -2029,25 +2084,14 @@ fn edit_custom_field(
     let mut fields = entry.fields.clone();
     fields[idx].value = Some(encrypted);
 
-    let access_token = db.access_token.as_ref().unwrap();
-    let refresh_token = db.refresh_token.as_ref().unwrap();
-    if let (Some(access_token), ()) = rbw::actions::edit(
-        access_token,
-        refresh_token,
-        &entry.id,
-        entry.org_id.as_deref(),
-        &entry.name,
+    put_cipher(
+        db,
+        entry,
         &entry.data,
         &fields,
         entry.notes.as_deref(),
-        entry.folder_id.as_deref(),
         &entry.history,
-        entry.key.as_deref(),
-    )? {
-        db.access_token = Some(access_token);
-        save_db(db)?;
-    }
-    Ok(())
+    )
 }
 
 pub fn remove(
@@ -2187,15 +2231,27 @@ fn version_or_quit() -> anyhow::Result<u32> {
 
 fn find_entry(
     db: &rbw::db::Db,
-    mut needle: Needle,
+    needle: Needle,
     username: Option<&str>,
     folder: Option<&str>,
     ignore_case: bool,
 ) -> anyhow::Result<(rbw::db::Entry, DecryptedCipher)> {
+    let entry = find_db_entry(db, needle, username, folder, ignore_case)?;
+    let decrypted_entry = decrypt_cipher(&entry)?;
+    Ok((entry, decrypted_entry))
+}
+
+fn find_db_entry(
+    db: &rbw::db::Db,
+    mut needle: Needle,
+    username: Option<&str>,
+    folder: Option<&str>,
+    ignore_case: bool,
+) -> anyhow::Result<rbw::db::Entry> {
     if let Needle::Uuid(uuid, s) = needle {
         for cipher in &db.entries {
             if uuid::Uuid::parse_str(&cipher.id) == Ok(uuid) {
-                return Ok((cipher.clone(), decrypt_cipher(cipher)?));
+                return Ok(cipher.clone());
             }
         }
         needle = Needle::Name(s);
@@ -2211,8 +2267,27 @@ fn find_entry(
         .collect::<anyhow::Result<_>>()?;
     let (entry, _) =
         find_entry_raw(&ciphers, &needle, username, folder, ignore_case)?;
-    let decrypted_entry = decrypt_cipher(&entry)?;
-    Ok((entry, decrypted_entry))
+    Ok(entry)
+}
+
+fn print_editable_custom_field_names(
+    entry: &rbw::db::Entry,
+) -> anyhow::Result<()> {
+    for field in &entry.fields {
+        if field.ty == Some(rbw::api::FieldType::Linked) {
+            continue;
+        }
+        let Some(name) = &field.name else {
+            continue;
+        };
+        let name = crate::actions::decrypt(
+            name,
+            entry.key.as_deref(),
+            entry.org_id.as_deref(),
+        )?;
+        println!("{name}");
+    }
+    Ok(())
 }
 
 fn find_entry_raw(
@@ -4332,6 +4407,8 @@ mod test {
                 history: vec![],
                 key: None,
                 master_password_reprompt: rbw::api::CipherRepromptType::None,
+                favorite: false,
+                archived_date: None,
             },
             DecryptedSearchCipher {
                 id: id.to_string(),
@@ -4395,49 +4472,62 @@ mod test {
     }
 
     #[test]
-    fn test_strip_appended_help_keeps_user_hash_lines() {
+    fn test_strip_help_block() {
         let contents = format!("value\n#keep{HELP_FIELD}");
         assert_eq!(
-            strip_appended_help(&contents, HELP_FIELD),
+            strip_help_block(&contents, HELP_FIELD).unwrap(),
             "value\n#keep"
         );
-        let with_extra_nl = format!("value\n#keep{HELP_FIELD}\n");
+        let crlf =
+            format!("value\r\n#keep{}", HELP_FIELD.replace('\n', "\r\n"));
         assert_eq!(
-            strip_appended_help(&with_extra_nl, HELP_FIELD),
+            strip_help_block(&crlf, HELP_FIELD).unwrap(),
             "value\n#keep"
         );
+        let after = format!("value{HELP_FIELD}# mine\n");
         assert_eq!(
-            strip_appended_help("just-piped\n", HELP_FIELD),
+            strip_help_block(&after, HELP_FIELD).unwrap(),
+            "value\n# mine"
+        );
+        // User deleted the value line and left only the help: empty, so
+        // read_custom_field_value will refuse rather than save the stub.
+        assert_eq!(strip_help_block(HELP_FIELD, HELP_FIELD).unwrap(), "");
+        let leftover =
+            format!("value\n{}", HELP_FIELD.lines().nth(1).unwrap());
+        assert!(strip_help_block(&leftover, HELP_FIELD).is_err());
+        assert_eq!(
+            strip_help_block("just-piped\n", HELP_FIELD).unwrap(),
             "just-piped"
         );
     }
 
     #[test]
-    fn test_validate_custom_field_value() {
-        assert!(validate_custom_field_value(
+    fn test_validate_boolean_field() {
+        assert!(validate_boolean_field(
             Some(rbw::api::FieldType::Hidden),
             "any"
         )
         .is_ok());
-        assert!(validate_custom_field_value(
+        assert!(validate_boolean_field(
             Some(rbw::api::FieldType::Boolean),
             "true"
         )
         .is_ok());
-        assert!(validate_custom_field_value(
+        assert!(validate_boolean_field(
             Some(rbw::api::FieldType::Boolean),
             "false"
         )
         .is_ok());
-        assert!(validate_custom_field_value(
+        assert!(validate_boolean_field(
             Some(rbw::api::FieldType::Boolean),
             "yes"
         )
         .is_err());
-        assert!(validate_custom_field_value(
+        // Linked is rejected before read/validate, not here.
+        assert!(validate_boolean_field(
             Some(rbw::api::FieldType::Linked),
             "anything"
         )
-        .is_err());
+        .is_ok());
     }
 }

--- a/src/bin/rbw/commands.rs
+++ b/src/bin/rbw/commands.rs
@@ -2249,6 +2249,7 @@ fn edit_custom_field(
             field_name,
             &new_value,
             original_ct.as_deref(),
+            &current,
         ),
     )
 }
@@ -2298,12 +2299,32 @@ fn decrypt_custom_field_value(
         .map(std::option::Option::unwrap_or_default)
 }
 
+/// True when a concurrent save changed this field's plaintext.
+///
+/// Ciphertext inequality is not enough. Official Bitwarden clients
+/// encrypt `CipherView` from scratch on every save
+/// (`FieldView::encrypt_composite` always encrypts name+value). AES-CBC
+/// uses a random IV, so a notes-only edit rotates this field's
+/// ciphertext while leaving the value alone. rbw itself leaves
+/// untouched fields' ciphertext unchanged, so equal ciphertext is a
+/// decrypt-free fast path.
+fn target_field_plaintext_changed(
+    original_ciphertext: Option<&str>,
+    original_plaintext: &str,
+    server_ciphertext: Option<&str>,
+    server_plaintext: &str,
+) -> bool {
+    original_ciphertext != server_ciphertext
+        && original_plaintext != server_plaintext
+}
+
 fn put_field_plaintext(
     db: &mut rbw::db::Db,
     entry: &rbw::db::Entry,
     field_name: &str,
     plaintext: &str,
     original_ciphertext: Option<&str>,
+    original_plaintext: &str,
 ) -> anyhow::Result<()> {
     let (data, fields, notes, history) =
         encrypt_named_field(entry, field_name, plaintext)?;
@@ -2321,12 +2342,19 @@ fn put_field_plaintext(
                     anyhow::anyhow!("entry disappeared after conflict sync")
                 })?;
             let (idx, ty) = named_custom_field(&entry, field_name)?;
-            if entry.fields[idx].value.as_deref() != original_ciphertext {
-                // Another client changed this same field. Rebase would
-                // use the new revision and silently overwrite them.
-                return Err(err.context(
-                    "the same custom field was changed on the server",
-                ));
+            let server_ct = entry.fields[idx].value.as_deref();
+            if original_ciphertext != server_ct {
+                let server_pt = decrypt_custom_field_value(&entry, idx)?;
+                if target_field_plaintext_changed(
+                    original_ciphertext,
+                    original_plaintext,
+                    server_ct,
+                    &server_pt,
+                ) {
+                    return Err(err.context(
+                        "the same custom field was changed on the server",
+                    ));
+                }
             }
             validate_boolean_field(ty, plaintext)?;
             let (data, fields, notes, history) =
@@ -4851,6 +4879,24 @@ mod test {
             "anything"
         )
         .is_ok());
+    }
+
+    #[test]
+    fn test_target_field_plaintext_changed() {
+        let old_ct = Some("2.aaa");
+        let new_ct = Some("2.bbb");
+        assert!(!target_field_plaintext_changed(
+            old_ct, "token", old_ct, "token"
+        ));
+        // Official client re-encrypted the field in place.
+        assert!(!target_field_plaintext_changed(
+            old_ct, "token", new_ct, "token"
+        ));
+        assert!(target_field_plaintext_changed(
+            old_ct, "token", new_ct, "other"
+        ));
+        assert!(!target_field_plaintext_changed(None, "", None, ""));
+        assert!(target_field_plaintext_changed(None, "", new_ct, "other"));
     }
 
     #[test]

--- a/src/bin/rbw/commands.rs
+++ b/src/bin/rbw/commands.rs
@@ -1227,17 +1227,27 @@ const HELP_NOTES: &str = r"
 # Lines with leading # will be ignored.
 ";
 
-const HELP_START: &str = "# --- rbw field help start ---";
-const HELP_END: &str = "# --- rbw field help end ---";
+fn unique_help_markers(current: &str) -> (String, String) {
+    use rand::distr::SampleString as _;
+    loop {
+        let nonce =
+            rand::distr::Alphanumeric.sample_string(&mut rand::rng(), 16);
+        let start = format!("# --- rbw field help start {nonce} ---");
+        let end = format!("# --- rbw field help end {nonce} ---");
+        if !current.contains(&start) && !current.contains(&end) {
+            return (start, end);
+        }
+    }
+}
 
-fn field_help(boolean: bool) -> String {
+fn field_help(boolean: bool, start: &str, end: &str) -> String {
     let body = if boolean {
         "# Enter true or false (nothing else).\n# Empty values are refused."
     } else {
         "# The content of this file will be stored as the custom field value.\n\
          # Empty values are refused."
     };
-    format!("\n{HELP_START}\n{body}\n{HELP_END}\n")
+    format!("\n{start}\n{body}\n{end}\n")
 }
 
 pub fn config_show() -> anyhow::Result<()> {
@@ -1782,27 +1792,23 @@ pub fn edit(
 ) -> anyhow::Result<()> {
     unlock()?;
 
-    let mut db = load_db()?;
-
     let desc = format!(
         "{}{}",
         username.map_or_else(String::new, |s| format!("{s}@")),
         name
     );
 
+    // Resolve the selector against a fresh vault. Finding by name/URI in
+    // the old cache and then refreshing *that ID* would edit the wrong
+    // cipher if the name had been moved to another item.
+    crate::actions::sync()?;
+    let mut db = load_db()?;
     let entry = find_db_entry(&db, name, username, folder, ignore_case)
         .with_context(|| format!("couldn't find entry for '{desc}'"))?;
-    // Bitwarden has no single-field PATCH. A full PUT from a stale cache
-    // overwrites password/notes and, on a 1.15.0 cache, sends
-    // serde-default favorite=false. Sync first so the snapshot matches
-    // the server; lastKnownRevisionDate then rejects races while the
-    // editor is open. Do not sync again until after PUT.
-    let entry = refresh_entry(&mut db, &entry.id)?;
     let decrypted = decrypt_cipher(&entry)?;
 
     if let Some(field_name) = field {
         edit_custom_field(&mut db, &entry, &decrypted, field_name)?;
-        crate::actions::sync()?;
         return Ok(());
     }
 
@@ -1899,22 +1905,7 @@ pub fn edit(
     };
 
     put_cipher(&mut db, &entry, &data, &fields, notes.as_deref(), &history)?;
-
-    crate::actions::sync()?;
     Ok(())
-}
-
-fn refresh_entry(
-    db: &mut rbw::db::Db,
-    id: &str,
-) -> anyhow::Result<rbw::db::Entry> {
-    crate::actions::sync()?;
-    *db = load_db()?;
-    db.entries
-        .iter()
-        .find(|entry| entry.id == id)
-        .cloned()
-        .ok_or_else(|| anyhow::anyhow!("entry disappeared after sync"))
 }
 
 fn put_cipher(
@@ -1928,7 +1919,7 @@ fn put_cipher(
     let meta = entry.cipher_write_meta();
     let access_token = db.access_token.as_ref().unwrap();
     let refresh_token = db.refresh_token.as_ref().unwrap();
-    if let (Some(access_token), ()) = rbw::actions::edit(
+    let (new_token, ()) = rbw::actions::edit(
         access_token,
         refresh_token,
         &entry.id,
@@ -1940,10 +1931,21 @@ fn put_cipher(
         entry.folder_id.as_deref(),
         history,
         &meta,
-    )? {
-        db.access_token = Some(access_token);
-        save_db(db)?;
+    )?;
+    if let Some(new_token) = new_token {
+        db.access_token = Some(new_token);
     }
+    // Patch the local snapshot so `rbw get` sees the write without a
+    // second full-vault sync. The next edit syncs before resolving the
+    // selector, so a slightly stale revision_date is harmless.
+    if let Some(slot) = db.entries.iter_mut().find(|item| item.id == entry.id)
+    {
+        slot.data = data.clone();
+        slot.fields = fields.to_vec();
+        slot.notes = notes.map(str::to_string);
+        slot.history = history.to_vec();
+    }
+    save_db(db)?;
     Ok(())
 }
 
@@ -1989,28 +1991,6 @@ fn strip_trailing_newlines(s: &str) -> String {
     s.trim_end_matches(['\n', '\r']).to_string()
 }
 
-fn line_without_cr(line: &str) -> &str {
-    line.trim_end_matches('\r')
-}
-
-fn help_residue_lines() -> impl Iterator<Item = &'static str> {
-    [
-        HELP_START,
-        HELP_END,
-        "# The content of this file will be stored as the custom field value.",
-        "# Enter true or false (nothing else).",
-        "# Empty values are refused.",
-    ]
-    .into_iter()
-}
-
-fn contains_help_residue(text: &str) -> bool {
-    text.lines().any(|line| {
-        let line = line_without_cr(line);
-        help_residue_lines().any(|help| line == help)
-    })
-}
-
 fn marker_span_start(raw: &str, marker_at: usize) -> usize {
     if marker_at >= 2
         && raw.as_bytes()[marker_at - 2] == b'\r'
@@ -2024,18 +2004,21 @@ fn marker_span_start(raw: &str, marker_at: usize) -> usize {
     }
 }
 
-fn strip_help_block(raw: &str) -> anyhow::Result<String> {
-    // Explicit start/end markers so we can delete the stub without
-    // rewriting the user's newlines. Matching on help prose as a suffix
-    // either ate `#` lines or, when the suffix failed, saved the stub.
-    // Consume the newline *before* START (inserted with the stub) but
-    // leave the newline after END so following user lines stay separate.
-    let start = raw.find(HELP_START);
-    let end = raw.find(HELP_END);
-    let combined = match (start, end) {
+fn strip_help_block(
+    raw: &str,
+    start: &str,
+    end: &str,
+) -> anyhow::Result<String> {
+    // Per-edit random markers: a user value may already contain a
+    // previous help fence. find() would then delete from that fence to
+    // the appended END and silently truncate. The nonce is chosen not
+    // to appear in the current value.
+    let start_at = raw.find(start);
+    let end_at = raw.find(end);
+    let combined = match (start_at, end_at) {
         (Some(s), Some(e)) if e > s => {
             let from = marker_span_start(raw, s);
-            let to = e + HELP_END.len();
+            let to = e + end.len();
             format!("{}{}", &raw[..from], &raw[to..])
         }
         (None, None) => raw.to_string(),
@@ -2044,7 +2027,7 @@ fn strip_help_block(raw: &str) -> anyhow::Result<String> {
              or remove it entirely"
         ),
     };
-    if contains_help_residue(&combined) {
+    if combined.contains(start) || combined.contains(end) {
         anyhow::bail!(
             "editor output still contains the help text; \
              remove it or leave the help block intact"
@@ -2057,14 +2040,18 @@ fn read_custom_field_value(
     current: &str,
     ty: Option<rbw::api::FieldType>,
 ) -> anyhow::Result<String> {
-    let help = field_help(ty == Some(rbw::api::FieldType::Boolean));
+    let (start, end) = unique_help_markers(current);
+    let help =
+        field_help(ty == Some(rbw::api::FieldType::Boolean), &start, &end);
     let mut current = current.to_string();
     let mut attempts = 0_u8;
     loop {
         let (raw, source) = rbw::edit::edit_from(&current, &help)?;
         let value = match source {
             rbw::edit::Source::Pipe => strip_trailing_newlines(&raw),
-            rbw::edit::Source::Editor => strip_help_block(&raw)?,
+            rbw::edit::Source::Editor => {
+                strip_help_block(&raw, &start, &end)?
+            }
         };
         if value.is_empty() {
             anyhow::bail!("refusing to set an empty custom field value");
@@ -2122,23 +2109,79 @@ fn edit_custom_field(
 
     let current = field.value.clone().unwrap_or_default();
     let new_value = read_custom_field_value(&current, field.ty)?;
+    put_field_plaintext(db, entry, field_name, &new_value)
+}
+
+fn put_field_plaintext(
+    db: &mut rbw::db::Db,
+    entry: &rbw::db::Entry,
+    field_name: &str,
+    plaintext: &str,
+) -> anyhow::Result<()> {
+    let (data, fields, notes, history) =
+        encrypt_field_on_entry(entry, field_name, plaintext)?;
+    match put_cipher(db, entry, &data, &fields, notes.as_deref(), &history) {
+        Ok(()) => Ok(()),
+        Err(err)
+            if matches!(
+                err.downcast_ref::<rbw::error::Error>(),
+                Some(rbw::error::Error::CipherRevisionConflict)
+            ) =>
+        {
+            // Re-apply only the field on a fresh snapshot. Retrying the
+            // original full PUT would overwrite a password another client
+            // just saved.
+            crate::actions::sync()?;
+            *db = load_db()?;
+            let entry = db
+                .entries
+                .iter()
+                .find(|item| item.id == entry.id)
+                .cloned()
+                .ok_or_else(|| {
+                    anyhow::anyhow!("entry disappeared after conflict sync")
+                })?;
+            let (data, fields, notes, history) =
+                encrypt_field_on_entry(&entry, field_name, plaintext)?;
+            put_cipher(db, &entry, &data, &fields, notes.as_deref(), &history)
+        }
+        Err(err) => Err(err),
+    }
+}
+
+fn encrypt_field_on_entry(
+    entry: &rbw::db::Entry,
+    field_name: &str,
+    plaintext: &str,
+) -> anyhow::Result<(
+    rbw::db::EntryData,
+    Vec<rbw::db::Field>,
+    Option<String>,
+    Vec<rbw::db::HistoryEntry>,
+)> {
+    let decrypted = decrypt_cipher(entry)?;
+    if matches!(decrypted.data, DecryptedData::SshKey { .. }) {
+        anyhow::bail!(
+            "custom field edits are not supported for SSH key entries"
+        );
+    }
+    let idx = find_custom_field_index(&decrypted.fields, field_name)?;
+    if decrypted.fields[idx].ty == Some(rbw::api::FieldType::Linked) {
+        anyhow::bail!("linked custom fields cannot be edited as values");
+    }
     let encrypted = crate::actions::encrypt(
-        &new_value,
+        plaintext,
         entry.key.as_deref(),
         entry.org_id.as_deref(),
     )?;
-
     let mut fields = entry.fields.clone();
     fields[idx].value = Some(encrypted);
-
-    put_cipher(
-        db,
-        entry,
-        &entry.data,
-        &fields,
-        entry.notes.as_deref(),
-        &entry.history,
-    )
+    Ok((
+        entry.data.clone(),
+        fields,
+        entry.notes.clone(),
+        entry.history.clone(),
+    ))
 }
 
 pub fn remove(
@@ -4524,27 +4567,53 @@ mod test {
 
     #[test]
     fn test_strip_help_block() {
-        let help = field_help(false);
+        let start = "# --- rbw field help start TESTNONCE ---";
+        let end = "# --- rbw field help end TESTNONCE ---";
+        let help = field_help(false, start, end);
         let contents = format!("value\n#keep{help}");
-        assert_eq!(strip_help_block(&contents).unwrap(), "value\n#keep");
+        assert_eq!(
+            strip_help_block(&contents, start, end).unwrap(),
+            "value\n#keep"
+        );
 
         let crlf = format!("value\r\n#keep{}", help.replace('\n', "\r\n"));
-        assert_eq!(strip_help_block(&crlf).unwrap(), "value\r\n#keep");
+        assert_eq!(
+            strip_help_block(&crlf, start, end).unwrap(),
+            "value\r\n#keep"
+        );
 
         let after = format!("value{help}# mine\n");
-        assert_eq!(strip_help_block(&after).unwrap(), "value\n# mine");
+        assert_eq!(
+            strip_help_block(&after, start, end).unwrap(),
+            "value\n# mine"
+        );
 
-        assert_eq!(strip_help_block(&help).unwrap(), "");
-        assert_eq!(strip_help_block("just-piped\n").unwrap(), "just-piped");
+        assert_eq!(strip_help_block(&help, start, end).unwrap(), "");
+        assert_eq!(
+            strip_help_block("just-piped\n", start, end).unwrap(),
+            "just-piped"
+        );
 
         let crlf_value = format!("a\r\nb{help}");
-        assert_eq!(strip_help_block(&crlf_value).unwrap(), "a\r\nb");
+        assert_eq!(
+            strip_help_block(&crlf_value, start, end).unwrap(),
+            "a\r\nb"
+        );
 
-        let leftover_end = format!("value\n{HELP_END}\n");
-        assert!(strip_help_block(&leftover_end).is_err());
-        let leftover_body =
-            "value\n# Empty values are refused.\n".to_string();
-        assert!(strip_help_block(&leftover_body).is_err());
+        let stale = "# --- rbw field help start OLDNONCE ---";
+        let with_stale = format!("keep {stale} keep{help}");
+        assert_eq!(
+            strip_help_block(&with_stale, start, end).unwrap(),
+            format!("keep {stale} keep")
+        );
+
+        assert!(
+            strip_help_block(&format!("value\n{end}\n"), start, end).is_err()
+        );
+        assert!(strip_help_block(&format!("value\n{start}\n"), start, end)
+            .is_err());
+        let end_before_start = format!("value\n{end}\n{start}\n");
+        assert!(strip_help_block(&end_before_start, start, end).is_err());
     }
 
     #[test]

--- a/src/bin/rbw/commands.rs
+++ b/src/bin/rbw/commands.rs
@@ -1607,9 +1607,6 @@ pub fn add(
     let mut db = load_db()?;
     // unwrap is safe here because the call to unlock above is guaranteed to
     // populate these or error
-    let mut access_token = db.access_token.as_ref().unwrap().clone();
-    // Cloned so the post-editor closure can mutably borrow `db`.
-    let refresh_token = db.refresh_token.as_ref().unwrap().clone();
 
     let name = crate::actions::encrypt(name, None, None)?;
 
@@ -1621,87 +1618,94 @@ pub fn add(
     after_editor(
         source,
         &contents,
-        (|| {
-            let (password, notes) = parse_editor(&contents);
-            let password = password
-                .map(|password| {
-                    crate::actions::encrypt(&password, None, None)
-                })
-                .transpose()?;
-            let notes = notes
-                .map(|notes| crate::actions::encrypt(&notes, None, None))
-                .transpose()?;
-            let uris: Vec<_> = uris
-                .iter()
-                .map(|uri| {
-                    Ok(rbw::db::Uri {
-                        uri: crate::actions::encrypt(&uri.0, None, None)?,
-                        match_type: uri.1,
-                    })
-                })
-                .collect::<anyhow::Result<_>>()?;
+        add_after_editor(&mut db, &name, username, uris, folder, &contents),
+    )
+}
 
-            let mut folder_id = None;
-            if let Some(folder_name) = folder {
-                let (new_access_token, folders) = rbw::actions::list_folders(
-                    &access_token,
-                    &refresh_token,
-                )?;
-                if let Some(new_access_token) = new_access_token {
-                    access_token.clone_from(&new_access_token);
-                    db.access_token = Some(new_access_token);
-                    save_db(&db)?;
-                }
+fn add_after_editor(
+    db: &mut rbw::db::Db,
+    name: &str,
+    username: Option<String>,
+    uris: &[(String, Option<rbw::api::UriMatchType>)],
+    folder: Option<&str>,
+    contents: &str,
+) -> anyhow::Result<()> {
+    let mut access_token = db.access_token.as_ref().unwrap().clone();
+    let refresh_token = db.refresh_token.as_ref().unwrap().clone();
 
-                let folders: Vec<(String, String)> = folders
-                    .iter()
-                    .cloned()
-                    .map(|(id, name)| {
-                        Ok((id, crate::actions::decrypt(&name, None, None)?))
-                    })
-                    .collect::<anyhow::Result<_>>()?;
+    let (password, notes) = parse_editor(contents);
+    let password = password
+        .map(|password| crate::actions::encrypt(&password, None, None))
+        .transpose()?;
+    let notes = notes
+        .map(|notes| crate::actions::encrypt(&notes, None, None))
+        .transpose()?;
+    let uris: Vec<_> = uris
+        .iter()
+        .map(|uri| {
+            Ok(rbw::db::Uri {
+                uri: crate::actions::encrypt(&uri.0, None, None)?,
+                match_type: uri.1,
+            })
+        })
+        .collect::<anyhow::Result<_>>()?;
 
-                for (id, name) in folders {
-                    if name == folder_name {
-                        folder_id = Some(id);
-                    }
-                }
-                if folder_id.is_none() {
-                    let (new_access_token, id) = rbw::actions::create_folder(
-                        &access_token,
-                        &refresh_token,
-                        &crate::actions::encrypt(folder_name, None, None)?,
-                    )?;
-                    if let Some(new_access_token) = new_access_token {
-                        access_token.clone_from(&new_access_token);
-                        db.access_token = Some(new_access_token);
-                        save_db(&db)?;
-                    }
-                    folder_id = Some(id);
-                }
+    let mut folder_id = None;
+    if let Some(folder_name) = folder {
+        let (new_access_token, folders) =
+            rbw::actions::list_folders(&access_token, &refresh_token)?;
+        if let Some(new_access_token) = new_access_token {
+            access_token.clone_from(&new_access_token);
+            db.access_token = Some(new_access_token);
+            save_db(db)?;
+        }
+
+        let folders: Vec<(String, String)> = folders
+            .iter()
+            .cloned()
+            .map(|(id, name)| {
+                Ok((id, crate::actions::decrypt(&name, None, None)?))
+            })
+            .collect::<anyhow::Result<_>>()?;
+
+        for (id, name) in folders {
+            if name == folder_name {
+                folder_id = Some(id);
             }
-
-            if let (Some(access_token), ()) = rbw::actions::add(
+        }
+        if folder_id.is_none() {
+            let (new_access_token, id) = rbw::actions::create_folder(
                 &access_token,
                 &refresh_token,
-                &name,
-                &rbw::db::EntryData::Login {
-                    username,
-                    password,
-                    uris,
-                    totp: None,
-                },
-                notes.as_deref(),
-                folder_id.as_deref(),
-            )? {
-                db.access_token = Some(access_token);
-                save_db(&db)?;
+                &crate::actions::encrypt(folder_name, None, None)?,
+            )?;
+            if let Some(new_access_token) = new_access_token {
+                access_token.clone_from(&new_access_token);
+                db.access_token = Some(new_access_token);
+                save_db(db)?;
             }
+            folder_id = Some(id);
+        }
+    }
 
-            crate::actions::sync()?;
-            Ok(())
-        })(),
-    )
+    if let (Some(access_token), ()) = rbw::actions::add(
+        &access_token,
+        &refresh_token,
+        name,
+        &rbw::db::EntryData::Login {
+            username,
+            password,
+            uris,
+            totp: None,
+        },
+        notes.as_deref(),
+        folder_id.as_deref(),
+    )? {
+        db.access_token = Some(access_token);
+        save_db(db)?;
+    }
+
+    refresh_local_cache()
 }
 
 pub fn generate(
@@ -1794,7 +1798,7 @@ pub fn generate(
             save_db(&db)?;
         }
 
-        crate::actions::sync()?;
+        refresh_local_cache()?;
     }
 
     Ok(())
@@ -1846,65 +1850,7 @@ pub fn edit(
             after_editor(
                 source,
                 &contents,
-                (|| {
-                    let (password, notes) = parse_editor(&contents);
-                    let password = password
-                        .map(|password| {
-                            crate::actions::encrypt(
-                                &password,
-                                entry.key.as_deref(),
-                                entry.org_id.as_deref(),
-                            )
-                        })
-                        .transpose()?;
-                    let notes = notes
-                        .map(|notes| {
-                            crate::actions::encrypt(
-                                &notes,
-                                entry.key.as_deref(),
-                                entry.org_id.as_deref(),
-                            )
-                        })
-                        .transpose()?;
-                    let mut history = entry.history.clone();
-                    let rbw::db::EntryData::Login {
-                        username: entry_username,
-                        password: entry_password,
-                        uris: entry_uris,
-                        totp: entry_totp,
-                    } = &entry.data
-                    else {
-                        unreachable!();
-                    };
-
-                    if let Some(prev_password) = entry_password.clone() {
-                        let new_history_entry = rbw::db::HistoryEntry {
-                            last_used_date: format!(
-                                "{}",
-                                humantime::format_rfc3339(
-                                    std::time::SystemTime::now()
-                                )
-                            ),
-                            password: prev_password,
-                        };
-                        history.insert(0, new_history_entry);
-                    }
-
-                    let data = rbw::db::EntryData::Login {
-                        username: entry_username.clone(),
-                        password,
-                        uris: entry_uris.clone(),
-                        totp: entry_totp.clone(),
-                    };
-                    put_cipher(
-                        &mut db,
-                        &entry,
-                        &data,
-                        &entry.fields,
-                        notes.as_deref(),
-                        &history,
-                    )
-                })(),
+                put_login_edit(&mut db, &entry, &contents),
             )
         }
         DecryptedData::SecureNote => {
@@ -1917,27 +1863,7 @@ pub fn edit(
             after_editor(
                 source,
                 &contents,
-                (|| {
-                    // prepend blank line to be parsed as pw by `parse_editor`
-                    let (_, notes) = parse_editor(&format!("\n{contents}\n"));
-                    let notes = notes
-                        .map(|notes| {
-                            crate::actions::encrypt(
-                                &notes,
-                                entry.key.as_deref(),
-                                entry.org_id.as_deref(),
-                            )
-                        })
-                        .transpose()?;
-                    put_cipher(
-                        &mut db,
-                        &entry,
-                        &rbw::db::EntryData::SecureNote {},
-                        &entry.fields,
-                        notes.as_deref(),
-                        &entry.history,
-                    )
-                })(),
+                put_note_edit(&mut db, &entry, &contents),
             )
         }
         _ => Err(anyhow::anyhow!(
@@ -1950,6 +1876,87 @@ fn is_revision_conflict(err: &anyhow::Error) -> bool {
     matches!(
         err.downcast_ref::<rbw::error::Error>(),
         Some(rbw::error::Error::CipherRevisionConflict)
+    )
+}
+
+fn put_login_edit(
+    db: &mut rbw::db::Db,
+    entry: &rbw::db::Entry,
+    contents: &str,
+) -> anyhow::Result<()> {
+    let (password, notes) = parse_editor(contents);
+    let password = password
+        .map(|password| {
+            crate::actions::encrypt(
+                &password,
+                entry.key.as_deref(),
+                entry.org_id.as_deref(),
+            )
+        })
+        .transpose()?;
+    let notes = notes
+        .map(|notes| {
+            crate::actions::encrypt(
+                &notes,
+                entry.key.as_deref(),
+                entry.org_id.as_deref(),
+            )
+        })
+        .transpose()?;
+    let mut history = entry.history.clone();
+    let rbw::db::EntryData::Login {
+        username: entry_username,
+        password: entry_password,
+        uris: entry_uris,
+        totp: entry_totp,
+    } = &entry.data
+    else {
+        unreachable!();
+    };
+
+    if let Some(prev_password) = entry_password.clone() {
+        let new_history_entry = rbw::db::HistoryEntry {
+            last_used_date: format!(
+                "{}",
+                humantime::format_rfc3339(std::time::SystemTime::now())
+            ),
+            password: prev_password,
+        };
+        history.insert(0, new_history_entry);
+    }
+
+    let data = rbw::db::EntryData::Login {
+        username: entry_username.clone(),
+        password,
+        uris: entry_uris.clone(),
+        totp: entry_totp.clone(),
+    };
+    put_cipher(db, entry, &data, &entry.fields, notes.as_deref(), &history)
+}
+
+fn put_note_edit(
+    db: &mut rbw::db::Db,
+    entry: &rbw::db::Entry,
+    contents: &str,
+) -> anyhow::Result<()> {
+    // prepend blank line to be parsed as pw by `parse_editor`
+    let (_, notes) = parse_editor(&format!("\n{contents}\n"));
+    let notes = notes
+        .map(|notes| {
+            crate::actions::encrypt(
+                &notes,
+                entry.key.as_deref(),
+                entry.org_id.as_deref(),
+            )
+        })
+        .transpose()?;
+    put_cipher(
+        db,
+        entry,
+        &rbw::db::EntryData::SecureNote {},
+        &entry.fields,
+        notes.as_deref(),
+        &entry.history,
     )
 }
 
@@ -2015,12 +2022,52 @@ fn after_editor<T>(
     result: anyhow::Result<T>,
 ) -> anyhow::Result<T> {
     result.map_err(|err| {
-        if persist_unsaved_after_edit(source) {
+        // Server write already landed. Do not stash, and do not tell
+        // a pipe caller to regenerate the value.
+        if is_local_cache_refresh_failed(&err) {
+            err
+        } else if persist_unsaved_after_edit(source) {
             err_with_unsaved(err, plaintext)
         } else {
-            err
+            err.context(
+                "the piped value was not written to disk; \
+                 re-run the producing command",
+            )
         }
     })
+}
+
+#[derive(Debug)]
+struct LocalCacheRefreshFailed;
+
+impl std::fmt::Display for LocalCacheRefreshFailed {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(
+            "saved on the server, but local cache refresh failed; \
+             run `rbw sync` and do not retry the write",
+        )
+    }
+}
+
+impl std::error::Error for LocalCacheRefreshFailed {}
+
+fn refresh_local_cache() -> anyhow::Result<()> {
+    crate::actions::sync().context(LocalCacheRefreshFailed)
+}
+
+fn is_local_cache_refresh_failed(err: &anyhow::Error) -> bool {
+    // anyhow::Error::is sees a `.context(LocalCacheRefreshFailed)`
+    // wrapper; `chain()` downcast does not, because the concrete
+    // type is anyhow's private context object.
+    err.is::<LocalCacheRefreshFailed>()
+}
+
+pub fn exit_status(err: &anyhow::Error) -> i32 {
+    if is_local_cache_refresh_failed(err) {
+        2
+    } else {
+        1
+    }
 }
 
 fn put_cipher(
@@ -2054,12 +2101,10 @@ fn put_cipher(
     // Agent rebuilds the master-password-reprompt ciphertext set only
     // during sync, and only after the new vault is on disk. A failed
     // refresh here means disk and the in-memory set still match each
-    // other (both stale versus the server). Fail closed: the PUT
-    // succeeded, but this process cannot claim a consistent local view.
-    crate::actions::sync().context(
-        "edit saved on the server, but local cache refresh failed; \
-         run `rbw sync`",
-    )?;
+    // other (both stale versus the server). Fail closed with exit
+    // status 2: the PUT succeeded, but this process cannot claim a
+    // consistent local view. Callers must not retry the edit.
+    refresh_local_cache()?;
     *db = load_db()?;
     Ok(())
 }
@@ -4934,6 +4979,38 @@ mod test {
         .unwrap_err();
         let msg = format!("{err:#}");
         assert!(msg.contains("put failed"));
+        assert!(msg.contains("the piped value was not written to disk"));
         assert!(!msg.contains("plaintext you just typed"));
+    }
+
+    #[test]
+    fn test_after_editor_does_not_stash_after_server_save() {
+        let err = anyhow::anyhow!("network").context(LocalCacheRefreshFailed);
+        let err = after_editor::<()>(
+            rbw::edit::Source::Editor,
+            "typed-secret",
+            Err(err),
+        )
+        .unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("do not retry the write"));
+        assert!(!msg.contains("plaintext you just typed"));
+        assert_eq!(exit_status(&err), 2);
+        assert_eq!(exit_status(&anyhow::anyhow!("put failed")), 1);
+    }
+
+    #[test]
+    fn test_after_editor_pipe_does_not_rerun_after_server_save() {
+        let err = anyhow::anyhow!("network").context(LocalCacheRefreshFailed);
+        let err = after_editor::<()>(
+            rbw::edit::Source::Pipe,
+            "piped-secret",
+            Err(err),
+        )
+        .unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("do not retry the write"));
+        assert!(!msg.contains("the piped value was not written to disk"));
+        assert_eq!(exit_status(&err), 2);
     }
 }

--- a/src/bin/rbw/completion/rbw.fish
+++ b/src/bin/rbw/completion/rbw.fish
@@ -2,7 +2,7 @@ function __fish_rbw_get_completion_name
     set -l cmd (commandline -xpc)
     set -e cmd[1] # rbw
 
-    argparse -i folder= f/field= full raw clipboard i/ignorecase h/help l/list-fields -- $cmd
+    argparse -i folder= f/field= full raw clipboard i/ignorecase h/help l/list-fields list-custom-fields -- $cmd
     set -e argv[1] # get
 
     set -l candidates (command rbw list --fields name,folder,user)
@@ -57,7 +57,7 @@ function __fish_rbw_get_completion_fields
         set -e cmd[-1] # -f/--field
     end
 
-    argparse -i folder= f/field= full raw clipboard i/ignorecase h/help l/list-fields -- $cmd
+    argparse -i folder= f/field= full raw clipboard i/ignorecase h/help l/list-fields list-custom-fields -- $cmd
     set -e argv[1] # get
 
     if test (count $argv) -gt 0
@@ -65,14 +65,32 @@ function __fish_rbw_get_completion_fields
     end
 end
 
+function __fish_rbw_edit_completion_fields
+    set -l cmd (commandline -xpc)
+    set -e cmd[1] # rbw
+    if test -z "$(commandline -xpt)"
+        set -e cmd[-1] # -f/--field
+    end
+
+    argparse -i folder= f/field= i/ignorecase h/help -- $cmd
+    set -e argv[1] # edit
+
+    if test (count $argv) -gt 0
+        command rbw get "$argv[1]" --list-custom-fields 2>/dev/null
+    end
+end
+
 complete -f -c rbw -n '__fish_seen_subcommand_from get edit' -a '(__fish_rbw_get_completion_name)'
-complete -f -c rbw -n '__fish_seen_subcommand_from edit' -s f -l field -r -d 'Custom field to edit' -a '(__fish_rbw_get_completion_fields)'
+complete -f -c rbw -n '__fish_seen_subcommand_from edit' -s f -l field -r -d 'Custom field to edit' -a '(__fish_rbw_edit_completion_fields)'
 complete -f -c rbw -n '__fish_seen_subcommand_from edit' -l folder -r -d 'Folder name to search in' -a '(command rbw list --fields folder)'
+complete -f -c rbw -n '__fish_seen_subcommand_from edit' -s i -l ignorecase -d 'Ignore case'
+complete -f -c rbw -n '__fish_seen_subcommand_from edit' -s h -l help -d 'Print help'
 
 # Complete options for `rbw get`
 complete -f -c rbw -n '__fish_seen_subcommand_from get' -s i -l ignorecase -d 'Ignore case'
 complete -f -c rbw -n '__fish_seen_subcommand_from get' -s f -l field -r -d 'Field to get' -a '(__fish_rbw_get_completion_fields)'
 complete -f -c rbw -n '__fish_seen_subcommand_from get' -s l -l list-fields -r -d 'List fields in this entry'
+complete -f -c rbw -n '__fish_seen_subcommand_from get' -l list-custom-fields -d 'List custom fields in this entry'
 complete -f -c rbw -n '__fish_seen_subcommand_from get' -l folder -r -d 'Folder name to search in' -a '(command rbw list --fields folder)'
 complete -f -c rbw -n '__fish_seen_subcommand_from get' -l full -d 'Display the notes in addition to the password'
 complete -f -c rbw -n '__fish_seen_subcommand_from get' -l raw -d 'Display output as JSON'

--- a/src/bin/rbw/completion/rbw.fish
+++ b/src/bin/rbw/completion/rbw.fish
@@ -75,9 +75,21 @@ function __fish_rbw_edit_completion_fields
     argparse -i folder= f/field= i/ignorecase h/help -- $cmd
     set -e argv[1] # edit
 
-    if test (count $argv) -gt 0
-        command rbw get "$argv[1]" --list-custom-fields 2>/dev/null
+    if test (count $argv) -eq 0
+        return
     end
+    set -l get_args
+    if set -q _flag_folder
+        set -a get_args --folder $_flag_folder
+    end
+    if set -q _flag_ignorecase
+        set -a get_args --ignorecase
+    end
+    set -a get_args $argv[1]
+    if test (count $argv) -gt 1
+        set -a get_args $argv[2]
+    end
+    command rbw get $get_args --list-custom-fields 2>/dev/null
 end
 
 complete -f -c rbw -n '__fish_seen_subcommand_from get edit' -a '(__fish_rbw_get_completion_name)'

--- a/src/bin/rbw/completion/rbw.fish
+++ b/src/bin/rbw/completion/rbw.fish
@@ -66,6 +66,8 @@ function __fish_rbw_get_completion_fields
 end
 
 complete -f -c rbw -n '__fish_seen_subcommand_from get edit' -a '(__fish_rbw_get_completion_name)'
+complete -f -c rbw -n '__fish_seen_subcommand_from edit' -s f -l field -r -d 'Custom field to edit' -a '(__fish_rbw_get_completion_fields)'
+complete -f -c rbw -n '__fish_seen_subcommand_from edit' -l folder -r -d 'Folder name to search in' -a '(command rbw list --fields folder)'
 
 # Complete options for `rbw get`
 complete -f -c rbw -n '__fish_seen_subcommand_from get' -s i -l ignorecase -d 'Ignore case'

--- a/src/bin/rbw/main.rs
+++ b/src/bin/rbw/main.rs
@@ -84,7 +84,11 @@ enum Opt {
         clipboard: bool,
         #[structopt(short, long, help = "List fields in this entry")]
         list_fields: bool,
-        #[arg(long, help = "List custom fields in this entry")]
+        #[arg(
+            long,
+            help = "List custom fields in this entry (not linked fields)",
+            conflicts_with = "list_fields"
+        )]
         list_custom_fields: bool,
     },
 
@@ -211,8 +215,9 @@ enum Opt {
             password and notes. Piped stdin is stored as the new value \
             (trailing newlines are stripped); an interactive terminal \
             opens the editor. The named custom field must already exist. \
-            Empty values are refused. SSH key entries and linked fields \
-            cannot be edited this way."
+            Empty values are refused. Login, secure note, card, and \
+            identity entries are supported; SSH key entries and linked \
+            fields cannot be edited this way."
     )]
     Edit {
         #[command(flatten)]

--- a/src/bin/rbw/main.rs
+++ b/src/bin/rbw/main.rs
@@ -204,11 +204,21 @@ enum Opt {
             The editor to use is determined  by the value of the \
             $VISUAL or $EDITOR environment variables. The first line \
             will be saved as the password and the remainder will be saved \
-            as a note."
+            as a note.\n\n\
+            Pass --field to change a custom field instead of the \
+            password and notes. Piped stdin is stored as the new value \
+            (a trailing newline is stripped); an interactive terminal \
+            opens the editor. The named custom field must already exist."
     )]
     Edit {
         #[command(flatten)]
         find_args: FindArgs,
+        #[arg(
+            short,
+            long,
+            help = "Custom field to edit instead of password/notes"
+        )]
+        field: Option<String>,
     },
 
     #[command(about = "Remove a given entry", visible_alias = "rm")]
@@ -430,11 +440,12 @@ fn main() {
                 ty,
             )
         }
-        Opt::Edit { find_args } => commands::edit(
+        Opt::Edit { find_args, field } => commands::edit(
             find_args.needle,
             find_args.user.as_deref(),
             find_args.folder.as_deref(),
             find_args.ignorecase,
+            field.as_deref(),
         ),
         Opt::Remove { find_args } => commands::remove(
             find_args.needle,

--- a/src/bin/rbw/main.rs
+++ b/src/bin/rbw/main.rs
@@ -84,6 +84,8 @@ enum Opt {
         clipboard: bool,
         #[structopt(short, long, help = "List fields in this entry")]
         list_fields: bool,
+        #[arg(long, help = "List custom fields in this entry")]
+        list_custom_fields: bool,
     },
 
     #[command(about = "Search for entries")]
@@ -207,8 +209,10 @@ enum Opt {
             as a note.\n\n\
             Pass --field to change a custom field instead of the \
             password and notes. Piped stdin is stored as the new value \
-            (a trailing newline is stripped); an interactive terminal \
-            opens the editor. The named custom field must already exist."
+            (trailing newlines are stripped); an interactive terminal \
+            opens the editor. The named custom field must already exist. \
+            Empty values are refused. SSH key entries and linked fields \
+            cannot be edited this way."
     )]
     Edit {
         #[command(flatten)]
@@ -356,6 +360,7 @@ fn main() {
             #[cfg(feature = "clipboard")]
             clipboard,
             list_fields,
+            list_custom_fields,
         } => commands::get(
             find_args.needle.clone(),
             find_args.user.as_deref(),
@@ -369,6 +374,7 @@ fn main() {
             false,
             find_args.ignorecase,
             list_fields,
+            list_custom_fields,
         ),
         Opt::Search {
             term,

--- a/src/bin/rbw/main.rs
+++ b/src/bin/rbw/main.rs
@@ -1,6 +1,5 @@
 use std::io::Write as _;
 
-use anyhow::Context as _;
 use clap::{CommandFactory as _, Parser as _};
 
 mod actions;
@@ -538,11 +537,11 @@ fn main() {
             }
             Ok(())
         }
-    }
-    .with_context(|| format!("rbw {subcommand_name}"));
+    };
 
     if let Err(e) = res {
-        eprintln!("{e:#}");
-        std::process::exit(1);
+        let code = commands::exit_status(&e);
+        eprintln!("{:#}", e.context(format!("rbw {subcommand_name}")));
+        std::process::exit(code);
     }
 }

--- a/src/bin/rbw/main.rs
+++ b/src/bin/rbw/main.rs
@@ -245,7 +245,8 @@ enum Opt {
     #[command(about = "Lock the password database")]
     Lock,
 
-    #[command(about = "Remove the local copy of the password database")]
+    #[command(about = "Remove the local copy of the password database, \
+            including unsaved editor buffers")]
     Purge,
 
     #[command(name = "stop-agent", about = "Terminate the background agent")]

--- a/src/db.rs
+++ b/src/db.rs
@@ -19,6 +19,14 @@ pub struct Entry {
     pub history: Vec<HistoryEntry>,
     pub key: Option<String>,
     pub master_password_reprompt: crate::api::CipherRepromptType,
+    // Official Bitwarden PUT maps omitted bool/enum/date fields to
+    // defaults (favorite=false, reprompt=None, archivedDate=null) via
+    // CipherRequestModel.ToCipherDetails(existingCipher). Persist what
+    // sync gave us so a field-only edit does not clobber them.
+    #[serde(default)]
+    pub favorite: bool,
+    #[serde(default)]
+    pub archived_date: Option<String>,
 }
 
 impl Entry {

--- a/src/db.rs
+++ b/src/db.rs
@@ -25,9 +25,13 @@ pub struct Entry {
     // sync gave us so a field-only edit does not clobber them.
     //
     // `serde(default)` is only for reading a 1.15.0 on-disk cache.
-    // Those defaults are not server truth — `refresh_entry` must sync
-    // before any cipher PUT so we do not unfavorite/unarchive on the
-    // first edit after upgrade.
+    // Those defaults are not server truth — `edit` syncs before
+    // resolving the selector so the first PUT after upgrade does not
+    // unfavorite/unarchive.
+    //
+    // Adding these fields is a Rust source break for downstream struct
+    // literals. JSON load stays compatible. Prefer `edit_with_meta`
+    // over constructing `Entry` by hand.
     #[serde(default)]
     pub favorite: bool,
     #[serde(default)]

--- a/src/db.rs
+++ b/src/db.rs
@@ -23,15 +23,43 @@ pub struct Entry {
     // defaults (favorite=false, reprompt=None, archivedDate=null) via
     // CipherRequestModel.ToCipherDetails(existingCipher). Persist what
     // sync gave us so a field-only edit does not clobber them.
+    //
+    // `serde(default)` is only for reading a 1.15.0 on-disk cache.
+    // Those defaults are not server truth — `refresh_entry` must sync
+    // before any cipher PUT so we do not unfavorite/unarchive on the
+    // first edit after upgrade.
     #[serde(default)]
     pub favorite: bool,
     #[serde(default)]
     pub archived_date: Option<String>,
+    #[serde(default)]
+    pub revision_date: Option<String>,
+}
+
+/// PUT metadata copied from a post-sync `Entry`. Prefer this over
+/// scattering more positional arguments; tests can lock the mapping.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CipherWriteMeta<'a> {
+    pub key: Option<&'a str>,
+    pub reprompt: crate::api::CipherRepromptType,
+    pub favorite: bool,
+    pub archived_date: Option<&'a str>,
+    pub last_known_revision_date: Option<&'a str>,
 }
 
 impl Entry {
     pub fn master_password_reprompt(&self) -> bool {
         self.master_password_reprompt != crate::api::CipherRepromptType::None
+    }
+
+    pub fn cipher_write_meta(&self) -> CipherWriteMeta<'_> {
+        CipherWriteMeta {
+            key: self.key.as_deref(),
+            reprompt: self.master_password_reprompt,
+            favorite: self.favorite,
+            archived_date: self.archived_date.as_deref(),
+            last_known_revision_date: self.revision_date.as_deref(),
+        }
     }
 }
 
@@ -320,5 +348,57 @@ impl Db {
             || self.iterations.is_none()
             || self.kdf.is_none()
             || self.protected_key.is_none()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_entry() -> Entry {
+        Entry {
+            id: "id".into(),
+            org_id: None,
+            folder: None,
+            folder_id: None,
+            name: "enc".into(),
+            data: EntryData::SecureNote,
+            fields: vec![],
+            notes: None,
+            history: vec![],
+            key: Some("item-key".into()),
+            master_password_reprompt:
+                crate::api::CipherRepromptType::Password,
+            favorite: true,
+            archived_date: Some("2026-01-01T00:00:00Z".into()),
+            revision_date: Some("2026-02-01T00:00:00Z".into()),
+        }
+    }
+
+    #[test]
+    fn cipher_write_meta_uses_entry_values_not_defaults() {
+        let entry = sample_entry();
+        let meta = entry.cipher_write_meta();
+        assert_eq!(meta.key, Some("item-key"));
+        assert_eq!(meta.reprompt, crate::api::CipherRepromptType::Password);
+        assert!(meta.favorite);
+        assert_eq!(meta.archived_date, Some("2026-01-01T00:00:00Z"));
+        assert_eq!(
+            meta.last_known_revision_date,
+            Some("2026-02-01T00:00:00Z")
+        );
+    }
+
+    #[test]
+    fn old_cache_json_defaults_are_not_server_truth() {
+        let mut value = serde_json::to_value(sample_entry()).unwrap();
+        let obj = value.as_object_mut().unwrap();
+        obj.remove("favorite");
+        obj.remove("archived_date");
+        obj.remove("revision_date");
+        let entry: Entry = serde_json::from_value(value).unwrap();
+        assert!(!entry.favorite);
+        assert!(entry.archived_date.is_none());
+        assert!(entry.revision_date.is_none());
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -30,8 +30,9 @@ pub struct Entry {
     // unfavorite/unarchive.
     //
     // Adding these fields is a Rust source break for downstream struct
-    // literals. JSON load stays compatible. Prefer `edit_with_meta`
-    // over constructing `Entry` by hand.
+    // literals. JSON load stays compatible. Cipher PUTs go through
+    // `edit_with_meta`; the 1.15 `edit` signatures are gone because
+    // they omitted `key` and reset favorite/archive.
     #[serde(default)]
     pub favorite: bool,
     #[serde(default)]

--- a/src/dirs.rs
+++ b/src/dirs.rs
@@ -71,6 +71,12 @@ pub fn ssh_agent_socket_file() -> std::path::PathBuf {
     runtime_dir().join("ssh-agent-socket")
 }
 
+/// Directory for editor buffers kept after a failed cipher PUT.
+/// Under the rbw runtime dir (not a shared world-readable $TMPDIR).
+pub fn unsaved_edit_dir() -> std::path::PathBuf {
+    runtime_dir().join("unsaved-edits")
+}
+
 fn config_dir() -> std::path::PathBuf {
     let project_dirs =
         directories::ProjectDirs::from("", "", &profile()).unwrap();

--- a/src/dirs.rs
+++ b/src/dirs.rs
@@ -10,7 +10,7 @@ pub fn make_all() -> Result<()> {
     Ok(())
 }
 
-fn create_dir_all_with_permissions(
+pub fn create_dir_all_with_permissions(
     path: &std::path::Path,
     mode: u32,
 ) -> Result<()> {

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -14,6 +14,11 @@ pub fn stdin_is_pipe() -> bool {
     !std::io::stdin().is_terminal()
 }
 
+/// Read an edited buffer from a pipe or `$VISUAL`/`$EDITOR`.
+///
+/// Drops whether the value came from a pipe. Prefer [`edit_from`] when
+/// the caller must treat those sources differently (for example to
+/// avoid writing piped secrets to disk).
 pub fn edit(contents: &str, help: &str) -> Result<String> {
     Ok(edit_from(contents, help)?.0)
 }

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -4,12 +4,26 @@ use std::io::{Read as _, Write as _};
 
 use is_terminal::IsTerminal as _;
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Source {
+    Pipe,
+    Editor,
+}
+
+pub fn stdin_is_pipe() -> bool {
+    !std::io::stdin().is_terminal()
+}
+
 pub fn edit(contents: &str, help: &str) -> Result<String> {
-    if !std::io::stdin().is_terminal() {
+    Ok(edit_from(contents, help)?.0)
+}
+
+pub fn edit_from(contents: &str, help: &str) -> Result<(String, Source)> {
+    if stdin_is_pipe() {
         // directly read from piped content
         return match std::io::read_to_string(std::io::stdin()) {
             Err(e) => Err(Error::FailedToReadFromStdin { err: e }),
-            Ok(res) => Ok(res),
+            Ok(res) => Ok((res, Source::Pipe)),
         };
     }
 
@@ -87,7 +101,7 @@ pub fn edit(contents: &str, help: &str) -> Result<String> {
     fh.read_to_string(&mut contents).unwrap();
     drop(fh);
 
-    Ok(contents)
+    Ok((contents, Source::Editor))
 }
 
 fn contains_shell_metacharacters(cmd: &std::ffi::OsStr) -> bool {

--- a/src/error.rs
+++ b/src/error.rs
@@ -75,6 +75,12 @@ pub enum Error {
     InvalidCipherString { reason: String },
 
     #[error(
+        "cipher was changed on the server since this snapshot; \
+         run rbw sync and retry"
+    )]
+    CipherRevisionConflict,
+
+    #[error(
         "invalid value for ${var}: {}",
         .editor.to_string_lossy()
     )]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,5 +1,18 @@
 use std::os::unix::ffi::{OsStrExt as _, OsStringExt as _};
 
+/// Increment when the client/agent JSON protocol changes, even if the
+/// crate version does not.
+///
+/// serde ignores unknown `Action` fields. A leftover 1.15.0 agent would
+/// therefore accept `Encrypt` without `entry_key`, encrypt with the
+/// user/org key, and the new CLI would PUT that ciphertext while still
+/// sending the item `key` — mixed-key corruption. `ensure_agent()`
+/// compares [`VERSION`] and restarts the agent on mismatch, so this
+/// revision is the fail-closed gate. Do not rely on bumping Cargo.toml
+/// alone: the crate-version term below collides for some triples
+/// (1.15.1 and 1.16.0 both add to `17_000_000`).
+pub const PROTOCOL_REVISION: u32 = 1;
+
 pub const VERSION: u32 = {
     const fn unwrap(res: &Result<u32, std::num::ParseIntError>) -> u32 {
         match res {
@@ -15,6 +28,7 @@ pub const VERSION: u32 = {
     unwrap(&u32::from_str_radix(major, 10)) * 1_000_000
         + unwrap(&u32::from_str_radix(minor, 10)) * 1_000_000
         + unwrap(&u32::from_str_radix(patch, 10)) * 1_000_000
+        + PROTOCOL_REVISION
 };
 
 #[derive(serde::Serialize, serde::Deserialize, Debug)]
@@ -181,6 +195,8 @@ pub enum Action {
     },
     Encrypt {
         plaintext: String,
+        // Bump PROTOCOL_REVISION when this shape changes. Unknown fields
+        // are ignored, so an old agent would encrypt without this key.
         entry_key: Option<String>,
         org_id: Option<String>,
     },

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -216,3 +216,54 @@ pub enum Response {
     Encrypt { cipherstring: String },
     Version { version: u32 },
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn version_includes_protocol_revision() {
+        let crate_part = VERSION - PROTOCOL_REVISION;
+        assert_eq!(VERSION, crate_part + PROTOCOL_REVISION);
+        assert_ne!(VERSION, crate_part);
+    }
+
+    #[test]
+    fn encrypt_action_accepts_legacy_json_without_entry_key() {
+        let action: Action = serde_json::from_str(
+            r#"{"type":"Encrypt","plaintext":"p","org_id":null}"#,
+        )
+        .unwrap();
+        match action {
+            Action::Encrypt {
+                plaintext,
+                entry_key,
+                org_id,
+            } => {
+                assert_eq!(plaintext, "p");
+                assert!(entry_key.is_none());
+                assert!(org_id.is_none());
+            }
+            _ => panic!("expected Encrypt"),
+        }
+    }
+
+    #[test]
+    fn encrypt_action_roundtrips_entry_key() {
+        let action = Action::Encrypt {
+            plaintext: "p".into(),
+            entry_key: Some("k".into()),
+            org_id: None,
+        };
+        let json = serde_json::to_string(&action).unwrap();
+        assert!(json.contains("entry_key"));
+        let back: Action = serde_json::from_str(&json).unwrap();
+        match back {
+            Action::Encrypt {
+                entry_key: Some(key),
+                ..
+            } => assert_eq!(key, "k"),
+            other => panic!("expected Encrypt with key, got {other:?}"),
+        }
+    }
+}

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -181,6 +181,7 @@ pub enum Action {
     },
     Encrypt {
         plaintext: String,
+        entry_key: Option<String>,
         org_id: Option<String>,
     },
     ClipboardStore {

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -223,9 +223,7 @@ mod tests {
 
     #[test]
     fn version_includes_protocol_revision() {
-        let crate_part = VERSION - PROTOCOL_REVISION;
-        assert_eq!(VERSION, crate_part + PROTOCOL_REVISION);
-        assert_ne!(VERSION, crate_part);
+        assert_eq!(VERSION % 1_000_000, PROTOCOL_REVISION);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `rbw edit --field=<name>` updates one existing custom field on login, secure note, card, and identity entries.
- The vault is synced **before** the name/URI selector is resolved, then again after a successful PUT so the agent rebuilds its master-password-reprompt set. Agent sync writes the vault **before** replacing that in-memory set (same lock). Any local failure after the server write (token save, cache refresh, reload) is **exit 2** (`rbw sync`, do not retry the write); a write that never landed stays exit 1.
- Piped stdin is the new value (trailing newlines stripped) and is **not** written to disk on failure (the error says to re-run the producing command). An interactive editor uses per-edit random help markers; leftover help body is refused; failed editor edits stash plaintext under the rbw runtime `unsaved-edits/` directory (0700 / files 0600 `O_EXCL`) for `rbw add` and `rbw edit`. `rbw purge` removes that directory.
- Empty values are refused. SSH key entries and linked fields are refused. Boolean fields must be `true`/`false`.
- Encrypt with the entry item key when present and send `key` on PUT (#364 / #368). Cipher PUT also sends `reprompt`, `favorite`, `archivedDate`, and `lastKnownRevisionDate`.
- HTTP 400 bodies containing "out of date" (and 409) map to `CipherRevisionConflict`. Field edits rebase unless the target field's **plaintext** changed (official clients re-encrypt every custom field on save, so ciphertext inequality is not a same-field edit).
- `rbw get --list-custom-fields` lists editable custom field names without decrypting hidden values.
- Library: `db::Entry` gained `favorite` / `archived_date` / `revision_date` (JSON-compatible via `serde(default)`; Rust struct-literal break). `actions::edit` / `Client::edit` are removed — they omitted item `key` and reset favorite/archive. Use `edit_with_meta`. `rbw::edit::edit` stays as the source-agnostic wrapper around `edit_from`.

Depends on: #368
Related: #364

## Test plan
- [x] `cargo test --lib --bin rbw`
- [x] `cargo clippy --bin rbw --lib -- -D warnings`
- [ ] Pipe a new value into `rbw edit --field=<existing> <entry>` and confirm `rbw get --field=<existing>` returns it
- [ ] Failed pipe edit does not create a file under `unsaved-edits/` and mentions re-running the producer
- [ ] Failed editor edit creates a 0600 file; `rbw purge` removes the directory
- [ ] Concurrent change to another field (including via the official client, which re-encrypts all fields) rebases; concurrent change to the same field's plaintext conflicts
- [ ] Keyed item still decrypts after `--field` edit
- [ ] `rbw edit --field` on an SSH key / linked field errors

