### PR TITLE
Fix cipher write safety and retry semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## Unreleased
+
+## Changed
+
+* `db::Entry` now includes `favorite`, `archived_date`, and
+  `revision_date` so cipher PUTs can round-trip those values.
+  This is a Rust source break for struct literals and exhaustive
+  matches; JSON cache load stays compatible via `serde(default)`.
+* `actions::edit` and `Client::edit` are removed. They omitted item
+  `key` and wrote `favorite=false` / `archivedDate=null`, which could
+  mix-key-corrupt keyed items and unfavorite/unarchive others. Use
+  `edit_with_meta`.
+
+## Fixed
+
+* `rbw edit` encrypts with the entry's individual item key when present
+  and preserves `key` on the cipher PUT, so keyed items are not corrupted
+  (#364, #368).
+* Cipher PUT now sends `reprompt`, `favorite`, `archivedDate`, and
+  `lastKnownRevisionDate`. `rbw edit` syncs before resolving the
+  name/URI selector, and again after a successful PUT so the agent
+  rebuilds its master-password-reprompt set. The agent writes the
+  vault to disk before replacing that in-memory set; a refresh
+  failure after a successful PUT is an error (`rbw sync`), not a
+  silent success. After the server write, any local follow-up failure
+  (token save, cache refresh, reload) makes `rbw add`, `rbw edit`, and
+  `rbw generate` exit 2 (not 1) and tells you not to retry the write.
+  Stale-cipher responses (HTTP 400 "out of date" or 409) map to a
+  conflict error.
+* A rejected interactive editor (`rbw add`, `rbw edit`) keeps the
+  plaintext in `$RBW runtime/unsaved-edits/` (directory mode 0700,
+  files 0600, `O_EXCL`) until you delete it. Piped stdin is not written
+  to disk. `rbw purge` removes that directory.
+
 ## [1.15.0] - 2025-12-31
 
 ## Added

--- a/README.md
+++ b/README.md
@@ -123,12 +123,19 @@ out by running `rbw purge`, and you can explicitly lock the database by running
 `rbw help` can be used to get more information about the available
 functionality.
 
-Run `rbw get <name>` to get your passwords. If you also want to get the username
-or the note associated, you can use the flag `--full`. You can also use the flag
-`--field={field}` to get whatever default or custom field you want. The `--raw`
-flag will show the output as JSON. In addition to matching against the name,
-you can pass a UUID as the name to search for the entry with that id, or a
-URL to search for an entry with a matching website entry.
+Run `rbw get <name>` to get your passwords. If you also want to get the
+username or the note associated, you can use the flag `--full`. You can
+also use the flag `--field={field}` to get whatever default or custom
+field you want. The `--raw` flag will show the output as JSON. `rbw edit`
+syncs the vault before opening the editor, so it needs network access.
+If an interactive editor save fails before the server write, the typed
+buffer is kept under the rbw runtime `unsaved-edits/` directory; delete
+it after recovering, or run `rbw purge`. Piped stdin is never written
+there. If the server write succeeded but the local cache could not be
+refreshed, the command exits 2 — run `rbw sync` and do not retry the
+write. In addition to matching against the name, you can pass a UUID as
+the name to search for the entry with that id, or a URL to search for an
+entry with a matching website entry.
 
 *Note to users of the official Bitwarden server (at bitwarden.com)*: The
 official server has a tendency to detect command line traffic as bot traffic

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -193,7 +193,7 @@ fn add_once(
     Ok(())
 }
 
-pub fn edit(
+pub fn edit_with_meta(
     access_token: &str,
     refresh_token: &str,
     id: &str,
@@ -204,6 +204,7 @@ pub fn edit(
     notes: Option<&str>,
     folder_uuid: Option<&str>,
     history: &[crate::db::HistoryEntry],
+    meta: &crate::db::CipherWriteMeta<'_>,
 ) -> Result<(Option<String>, ())> {
     with_exchange_refresh_token(access_token, refresh_token, |access_token| {
         edit_once(
@@ -216,6 +217,7 @@ pub fn edit(
             notes,
             folder_uuid,
             history,
+            meta,
         )
     })
 }
@@ -230,9 +232,10 @@ fn edit_once(
     notes: Option<&str>,
     folder_uuid: Option<&str>,
     history: &[crate::db::HistoryEntry],
+    meta: &crate::db::CipherWriteMeta<'_>,
 ) -> Result<()> {
     let (client, _) = api_client()?;
-    client.edit(
+    client.edit_with_meta(
         access_token,
         id,
         org_id,
@@ -242,6 +245,7 @@ fn edit_once(
         notes,
         folder_uuid,
         history,
+        meta,
     )?;
     Ok(())
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -428,6 +428,12 @@ struct SyncResCipher {
     key: Option<String>,
     #[serde(rename = "Reprompt", alias = "reprompt")]
     reprompt: CipherRepromptType,
+    #[serde(default, rename = "Favorite", alias = "favorite")]
+    favorite: bool,
+    #[serde(default, rename = "ArchivedDate", alias = "archivedDate")]
+    archived_date: Option<String>,
+    #[serde(default, rename = "RevisionDate", alias = "revisionDate")]
+    revision_date: Option<String>,
 }
 
 impl SyncResCipher {
@@ -551,6 +557,9 @@ impl SyncResCipher {
             history,
             key: self.key.clone(),
             master_password_reprompt: self.reprompt,
+            favorite: self.favorite,
+            archived_date: self.archived_date.clone(),
+            revision_date: self.revision_date.clone(),
         })
     }
 }
@@ -780,6 +789,21 @@ struct CiphersPutReq {
     secure_note: Option<CipherSecureNote>,
     #[serde(rename = "passwordHistory")]
     password_history: Vec<CiphersPutReqHistory>,
+    key: Option<String>,
+    // Non-optional on the official server; omitting them resets the
+    // live cipher (see CipherRequestModel.ToCipherDetails).
+    reprompt: CipherRepromptType,
+    favorite: bool,
+    #[serde(rename = "archivedDate")]
+    archived_date: Option<String>,
+    // Official server only conflict-checks when this is present. An
+    // omitted value allows a stale full PUT to overwrite a password or
+    // notes another client just saved.
+    #[serde(
+        rename = "lastKnownRevisionDate",
+        skip_serializing_if = "Option::is_none"
+    )]
+    last_known_revision_date: Option<String>,
 }
 
 #[derive(serde::Serialize, Debug)]
@@ -1317,7 +1341,7 @@ impl Client {
         }
     }
 
-    pub fn edit(
+    pub fn edit_with_meta(
         &self,
         access_token: &str,
         id: &str,
@@ -1328,6 +1352,7 @@ impl Client {
         notes: Option<&str>,
         folder_uuid: Option<&str>,
         history: &[crate::db::HistoryEntry],
+        meta: &crate::db::CipherWriteMeta<'_>,
     ) -> Result<()> {
         let mut req = CiphersPutReq {
             ty: match data {
@@ -1361,6 +1386,15 @@ impl Client {
                     password: entry.password.clone(),
                 })
                 .collect(),
+            key: meta.key.map(std::string::ToString::to_string),
+            reprompt: meta.reprompt,
+            favorite: meta.favorite,
+            archived_date: meta
+                .archived_date
+                .map(std::string::ToString::to_string),
+            last_known_revision_date: meta
+                .last_known_revision_date
+                .map(std::string::ToString::to_string),
         };
         match data {
             crate::db::EntryData::Login {
@@ -1456,15 +1490,12 @@ impl Client {
             .json(&req)
             .send()
             .map_err(|source| Error::Reqwest { source })?;
-        match res.status() {
-            reqwest::StatusCode::OK => Ok(()),
-            reqwest::StatusCode::UNAUTHORIZED => {
-                Err(Error::RequestUnauthorized)
-            }
-            _ => Err(Error::RequestFailed {
-                status: res.status().as_u16(),
-            }),
+        let status = res.status();
+        if status == reqwest::StatusCode::OK {
+            return Ok(());
         }
+        let body = res.text().unwrap_or_default();
+        Err(cipher_write_error(status, &body))
     }
 
     pub fn remove(&self, access_token: &str, id: &str) -> Result<()> {
@@ -1765,4 +1796,60 @@ fn classify_login_error(error_res: &ConnectErrorRes, code: u16) -> Error {
 
     log::warn!("unexpected error received during login: {error_res:?}");
     Error::RequestFailed { status: code }
+}
+
+fn cipher_write_error(status: reqwest::StatusCode, body: &str) -> Error {
+    // Official Bitwarden throws BadRequestException ("out of date") → 400.
+    // Vaultwarden uses err!("... out of date.") → also 400. Some forks
+    // might still use 409. Matching the body is what surfaces
+    // CipherRevisionConflict; status 409 is kept as a belt.
+    if status == reqwest::StatusCode::CONFLICT
+        || is_stale_cipher_message(body)
+    {
+        Error::CipherRevisionConflict
+    } else if status == reqwest::StatusCode::UNAUTHORIZED {
+        Error::RequestUnauthorized
+    } else {
+        Error::RequestFailed {
+            status: status.as_u16(),
+        }
+    }
+}
+
+fn is_stale_cipher_message(body: &str) -> bool {
+    body.to_ascii_lowercase().contains("out of date")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn revision_conflict_from_official_and_vaultwarden_bodies() {
+        assert!(matches!(
+            cipher_write_error(
+                reqwest::StatusCode::BAD_REQUEST,
+                "The item cannot be saved because it is out of date. Please reload and try again.",
+            ),
+            Error::CipherRevisionConflict
+        ));
+        assert!(matches!(
+            cipher_write_error(
+                reqwest::StatusCode::BAD_REQUEST,
+                r#"{"message":"The client copy of this cipher is out of date."}"#,
+            ),
+            Error::CipherRevisionConflict
+        ));
+        assert!(matches!(
+            cipher_write_error(reqwest::StatusCode::CONFLICT, ""),
+            Error::CipherRevisionConflict
+        ));
+        assert!(matches!(
+            cipher_write_error(
+                reqwest::StatusCode::BAD_REQUEST,
+                "Name is required",
+            ),
+            Error::RequestFailed { status: 400 }
+        ));
+    }
 }

--- a/src/bin/rbw-agent/actions.rs
+++ b/src/bin/rbw-agent/actions.rs
@@ -527,7 +527,6 @@ pub async fn sync(
     ) = rbw::actions::sync(&access_token, &refresh_token)
         .await
         .context("failed to sync database from server")?;
-    state.lock().await.set_master_password_reprompt(&entries);
     if let Some(access_token) = access_token {
         db.access_token = Some(access_token);
     }
@@ -535,7 +534,19 @@ pub async fn sync(
     db.protected_private_key = Some(protected_private_key);
     db.protected_org_keys = protected_org_keys;
     db.entries = entries;
-    save_db(&db).await?;
+    // Disk first, then the in-memory ciphertext set, under the same
+    // lock. The reverse order (or updating memory before a failed
+    // save) leaves the set matching the server while the on-disk
+    // cache still has the previous vault: decrypting an old hidden
+    // value would miss the set and skip master-password reprompt.
+    // Holding the lock across the save closes the window where a
+    // concurrent decrypt would see new disk bytes against the old
+    // set (the original skip-prompt bug this sync exists to fix).
+    {
+        let mut state = state.lock().await;
+        save_db(&db).await?;
+        state.set_master_password_reprompt(&db.entries);
+    }
 
     if let Err(e) = subscribe_to_notifications(state.clone()).await {
         eprintln!("failed to subscribe to notifications: {e}");
@@ -692,6 +703,7 @@ pub async fn encrypt(
     sock: &mut crate::sock::Sock,
     state: std::sync::Arc<tokio::sync::Mutex<crate::state::State>>,
     plaintext: &str,
+    entry_key: Option<&str>,
     org_id: Option<&str>,
 ) -> anyhow::Result<()> {
     let state = state.lock().await;
@@ -700,8 +712,20 @@ pub async fn encrypt(
             "failed to find encryption keys in in-memory state"
         ));
     };
+    let entry_keys = if let Some(entry_key) = entry_key {
+        let key_cipherstring =
+            rbw::cipherstring::CipherString::new(entry_key)
+                .context("failed to parse individual item encryption key")?;
+        Some(rbw::locked::Keys::new(
+            key_cipherstring.decrypt_locked_symmetric(keys).context(
+                "failed to decrypt individual item encryption key",
+            )?,
+        ))
+    } else {
+        None
+    };
     let cipherstring = rbw::cipherstring::CipherString::encrypt_symmetric(
-        keys,
+        entry_keys.as_ref().unwrap_or(keys),
         plaintext.as_bytes(),
     )
     .context("failed to encrypt plaintext secret")?;

--- a/src/bin/rbw-agent/agent.rs
+++ b/src/bin/rbw-agent/agent.rs
@@ -162,11 +162,16 @@ async fn handle_request(
             .await?;
             true
         }
-        rbw::protocol::Action::Encrypt { plaintext, org_id } => {
+        rbw::protocol::Action::Encrypt {
+            plaintext,
+            entry_key,
+            org_id,
+        } => {
             crate::actions::encrypt(
                 sock,
                 state.clone(),
                 plaintext,
+                entry_key.as_deref(),
                 org_id.as_deref(),
             )
             .await?;

--- a/src/bin/rbw/actions.rs
+++ b/src/bin/rbw/actions.rs
@@ -107,6 +107,7 @@ pub fn decrypt(
 
 pub fn encrypt(
     plaintext: &str,
+    entry_key: Option<&str>,
     org_id: Option<&str>,
 ) -> anyhow::Result<String> {
     let mut sock = connect()?;
@@ -114,6 +115,7 @@ pub fn encrypt(
         get_environment(),
         rbw::protocol::Action::Encrypt {
             plaintext: plaintext.to_string(),
+            entry_key: entry_key.map(std::string::ToString::to_string),
             org_id: org_id.map(std::string::ToString::to_string),
         },
     ))?;

--- a/src/bin/rbw/commands.rs
+++ b/src/bin/rbw/commands.rs
@@ -1566,29 +1566,51 @@ pub fn add(
     let mut db = load_db()?;
     // unwrap is safe here because the call to unlock above is guaranteed to
     // populate these or error
-    let mut access_token = db.access_token.as_ref().unwrap().clone();
-    let refresh_token = db.refresh_token.as_ref().unwrap();
 
-    let name = crate::actions::encrypt(name, None)?;
+    let encrypted_name = crate::actions::encrypt(name, None, None)?;
 
-    let username = username
-        .map(|username| crate::actions::encrypt(username, None))
+    let encrypted_username = username
+        .map(|username| crate::actions::encrypt(username, None, None))
         .transpose()?;
 
-    let contents = rbw::edit::edit("", HELP_PW)?;
+    let (contents, source) = rbw::edit::edit_from("", HELP_PW)?;
+    after_editor(
+        source,
+        &contents,
+        add_after_editor(
+            &mut db,
+            &encrypted_name,
+            encrypted_username,
+            uris,
+            folder,
+            &contents,
+        ),
+    )
+}
 
-    let (password, notes) = parse_editor(&contents);
+fn add_after_editor(
+    db: &mut rbw::db::Db,
+    encrypted_name: &str,
+    encrypted_username: Option<String>,
+    uris: &[(String, Option<rbw::api::UriMatchType>)],
+    folder: Option<&str>,
+    contents: &str,
+) -> anyhow::Result<()> {
+    let mut access_token = db.access_token.as_ref().unwrap().clone();
+    let refresh_token = db.refresh_token.as_ref().unwrap().clone();
+
+    let (password, notes) = parse_editor(contents);
     let password = password
-        .map(|password| crate::actions::encrypt(&password, None))
+        .map(|password| crate::actions::encrypt(&password, None, None))
         .transpose()?;
     let notes = notes
-        .map(|notes| crate::actions::encrypt(&notes, None))
+        .map(|notes| crate::actions::encrypt(&notes, None, None))
         .transpose()?;
     let uris: Vec<_> = uris
         .iter()
         .map(|uri| {
             Ok(rbw::db::Uri {
-                uri: crate::actions::encrypt(&uri.0, None)?,
+                uri: crate::actions::encrypt(&uri.0, None, None)?,
                 match_type: uri.1,
             })
         })
@@ -1597,11 +1619,11 @@ pub fn add(
     let mut folder_id = None;
     if let Some(folder_name) = folder {
         let (new_access_token, folders) =
-            rbw::actions::list_folders(&access_token, refresh_token)?;
+            rbw::actions::list_folders(&access_token, &refresh_token)?;
         if let Some(new_access_token) = new_access_token {
             access_token.clone_from(&new_access_token);
             db.access_token = Some(new_access_token);
-            save_db(&db)?;
+            save_db(db)?;
         }
 
         let folders: Vec<(String, String)> = folders
@@ -1620,38 +1642,32 @@ pub fn add(
         if folder_id.is_none() {
             let (new_access_token, id) = rbw::actions::create_folder(
                 &access_token,
-                refresh_token,
-                &crate::actions::encrypt(folder_name, None)?,
+                &refresh_token,
+                &crate::actions::encrypt(folder_name, None, None)?,
             )?;
             if let Some(new_access_token) = new_access_token {
                 access_token.clone_from(&new_access_token);
                 db.access_token = Some(new_access_token);
-                save_db(&db)?;
+                save_db(db)?;
             }
             folder_id = Some(id);
         }
     }
 
-    if let (Some(access_token), ()) = rbw::actions::add(
+    let (new_token, ()) = rbw::actions::add(
         &access_token,
-        refresh_token,
-        &name,
+        &refresh_token,
+        encrypted_name,
         &rbw::db::EntryData::Login {
-            username,
+            username: encrypted_username,
             password,
             uris,
             totp: None,
         },
         notes.as_deref(),
         folder_id.as_deref(),
-    )? {
-        db.access_token = Some(access_token);
-        save_db(&db)?;
-    }
-
-    crate::actions::sync()?;
-
-    Ok(())
+    )?;
+    after_server_write(db, new_token)
 }
 
 pub fn generate(
@@ -1674,16 +1690,16 @@ pub fn generate(
         let mut access_token = db.access_token.as_ref().unwrap().clone();
         let refresh_token = db.refresh_token.as_ref().unwrap();
 
-        let name = crate::actions::encrypt(name, None)?;
+        let name = crate::actions::encrypt(name, None, None)?;
         let username = username
-            .map(|username| crate::actions::encrypt(username, None))
+            .map(|username| crate::actions::encrypt(username, None, None))
             .transpose()?;
-        let password = crate::actions::encrypt(&password, None)?;
+        let password = crate::actions::encrypt(&password, None, None)?;
         let uris: Vec<_> = uris
             .iter()
             .map(|uri| {
                 Ok(rbw::db::Uri {
-                    uri: crate::actions::encrypt(&uri.0, None)?,
+                    uri: crate::actions::encrypt(&uri.0, None, None)?,
                     match_type: uri.1,
                 })
             })
@@ -1716,7 +1732,7 @@ pub fn generate(
                 let (new_access_token, id) = rbw::actions::create_folder(
                     &access_token,
                     refresh_token,
-                    &crate::actions::encrypt(folder_name, None)?,
+                    &crate::actions::encrypt(folder_name, None, None)?,
                 )?;
                 if let Some(new_access_token) = new_access_token {
                     access_token.clone_from(&new_access_token);
@@ -1727,7 +1743,7 @@ pub fn generate(
             }
         }
 
-        if let (Some(access_token), ()) = rbw::actions::add(
+        let (new_token, ()) = rbw::actions::add(
             &access_token,
             refresh_token,
             &name,
@@ -1739,12 +1755,8 @@ pub fn generate(
             },
             None,
             folder_id.as_deref(),
-        )? {
-            db.access_token = Some(access_token);
-            save_db(&db)?;
-        }
-
-        crate::actions::sync()?;
+        )?;
+        after_server_write(&mut db, new_token)?;
     }
 
     Ok(())
@@ -1758,21 +1770,23 @@ pub fn edit(
 ) -> anyhow::Result<()> {
     unlock()?;
 
-    let mut db = load_db()?;
-    let access_token = db.access_token.as_ref().unwrap();
-    let refresh_token = db.refresh_token.as_ref().unwrap();
-
     let desc = format!(
         "{}{}",
         username.map_or_else(String::new, |s| format!("{s}@")),
         name
     );
 
-    let (entry, decrypted) =
-        find_entry(&db, name, username, folder, ignore_case)
-            .with_context(|| format!("couldn't find entry for '{desc}'"))?;
+    // Resolve the selector against a fresh vault. Finding by name/URI in
+    // the old cache and then refreshing *that ID* would edit the wrong
+    // cipher if the name had been moved to another item.
+    crate::actions::sync()?;
+    let mut db = load_db()?;
+    let entry = find_db_entry(&db, name, username, folder, ignore_case)
+        .with_context(|| format!("couldn't find entry for '{desc}'"))?;
 
-    let (data, fields, notes, history) = match &decrypted.data {
+    let decrypted = decrypt_cipher(&entry)?;
+
+    match &decrypted.data {
         DecryptedData::Login { password, .. } => {
             let mut contents =
                 format!("{}\n", password.as_deref().unwrap_or(""));
@@ -1780,99 +1794,265 @@ pub fn edit(
                 write!(contents, "\n{notes}\n").unwrap();
             }
 
-            let contents = rbw::edit::edit(&contents, HELP_PW)?;
-
-            let (password, notes) = parse_editor(&contents);
-            let password = password
-                .map(|password| {
-                    crate::actions::encrypt(
-                        &password,
-                        entry.org_id.as_deref(),
-                    )
-                })
-                .transpose()?;
-            let notes = notes
-                .map(|notes| {
-                    crate::actions::encrypt(&notes, entry.org_id.as_deref())
-                })
-                .transpose()?;
-            let mut history = entry.history.clone();
-            let rbw::db::EntryData::Login {
-                username: entry_username,
-                password: entry_password,
-                uris: entry_uris,
-                totp: entry_totp,
-            } = &entry.data
-            else {
-                unreachable!();
-            };
-
-            if let Some(prev_password) = entry_password.clone() {
-                let new_history_entry = rbw::db::HistoryEntry {
-                    last_used_date: format!(
-                        "{}",
-                        humantime::format_rfc3339(
-                            std::time::SystemTime::now()
-                        )
-                    ),
-                    password: prev_password,
-                };
-                history.insert(0, new_history_entry);
-            }
-
-            let data = rbw::db::EntryData::Login {
-                username: entry_username.clone(),
-                password,
-                uris: entry_uris.clone(),
-                totp: entry_totp.clone(),
-            };
-            (data, entry.fields, notes, history)
+            let (contents, source) =
+                rbw::edit::edit_from(&contents, HELP_PW)?;
+            after_editor(
+                source,
+                &contents,
+                put_login_edit(&mut db, &entry, &contents),
+            )
         }
         DecryptedData::SecureNote => {
-            let data = rbw::db::EntryData::SecureNote {};
-
             let editor_content = decrypted.notes.map_or_else(
                 || "\n".to_string(),
                 |notes| format!("{notes}\n"),
             );
-            let contents = rbw::edit::edit(&editor_content, HELP_NOTES)?;
-
-            // prepend blank line to be parsed as pw by `parse_editor`
-            let (_, notes) = parse_editor(&format!("\n{contents}\n"));
-
-            let notes = notes
-                .map(|notes| {
-                    crate::actions::encrypt(&notes, entry.org_id.as_deref())
-                })
-                .transpose()?;
-
-            (data, entry.fields, notes, entry.history)
+            let (contents, source) =
+                rbw::edit::edit_from(&editor_content, HELP_NOTES)?;
+            after_editor(
+                source,
+                &contents,
+                put_note_edit(&mut db, &entry, &contents),
+            )
         }
-        _ => {
-            return Err(anyhow::anyhow!(
-                "modifications are only supported for login and note entries"
-            ));
-        }
+        _ => Err(anyhow::anyhow!(
+            "modifications are only supported for login and note entries"
+        )),
+    }
+}
+
+fn put_login_edit(
+    db: &mut rbw::db::Db,
+    entry: &rbw::db::Entry,
+    contents: &str,
+) -> anyhow::Result<()> {
+    let (password, notes) = parse_editor(contents);
+    let password = password
+        .map(|password| {
+            crate::actions::encrypt(
+                &password,
+                entry.key.as_deref(),
+                entry.org_id.as_deref(),
+            )
+        })
+        .transpose()?;
+    let notes = notes
+        .map(|notes| {
+            crate::actions::encrypt(
+                &notes,
+                entry.key.as_deref(),
+                entry.org_id.as_deref(),
+            )
+        })
+        .transpose()?;
+    let mut history = entry.history.clone();
+    let rbw::db::EntryData::Login {
+        username: entry_username,
+        password: entry_password,
+        uris: entry_uris,
+        totp: entry_totp,
+    } = &entry.data
+    else {
+        unreachable!();
     };
 
-    if let (Some(access_token), ()) = rbw::actions::edit(
+    if let Some(prev_password) = entry_password.clone() {
+        let new_history_entry = rbw::db::HistoryEntry {
+            last_used_date: format!(
+                "{}",
+                humantime::format_rfc3339(std::time::SystemTime::now())
+            ),
+            password: prev_password,
+        };
+        history.insert(0, new_history_entry);
+    }
+
+    let data = rbw::db::EntryData::Login {
+        username: entry_username.clone(),
+        password,
+        uris: entry_uris.clone(),
+        totp: entry_totp.clone(),
+    };
+    put_cipher(db, entry, &data, &entry.fields, notes.as_deref(), &history)
+}
+
+fn put_note_edit(
+    db: &mut rbw::db::Db,
+    entry: &rbw::db::Entry,
+    contents: &str,
+) -> anyhow::Result<()> {
+    // prepend blank line to be parsed as pw by `parse_editor`
+    let (_, notes) = parse_editor(&format!("\n{contents}\n"));
+    let notes = notes
+        .map(|notes| {
+            crate::actions::encrypt(
+                &notes,
+                entry.key.as_deref(),
+                entry.org_id.as_deref(),
+            )
+        })
+        .transpose()?;
+    put_cipher(
+        db,
+        entry,
+        &rbw::db::EntryData::SecureNote {},
+        &entry.fields,
+        notes.as_deref(),
+        &entry.history,
+    )
+}
+
+fn persist_unsaved_after_edit(source: rbw::edit::Source) -> bool {
+    // Piped stdin never touched disk; writing unsaved-edits/ would
+    // change that. Interactive editor buffers live in a tempfile that
+    // disappears when this process returns, so those are worth keeping.
+    source == rbw::edit::Source::Editor
+}
+
+fn persist_unsaved_edit(buf: &str) -> anyhow::Result<std::path::PathBuf> {
+    persist_unsaved_edit_in(&rbw::dirs::unsaved_edit_dir(), buf)
+}
+
+fn persist_unsaved_edit_in(
+    dir: &std::path::Path,
+    buf: &str,
+) -> anyhow::Result<std::path::PathBuf> {
+    use std::io::Write as _;
+    rbw::dirs::create_dir_all_with_permissions(dir, 0o700)
+        .with_context(|| format!("failed to create {}", dir.display()))?;
+    let path = dir.join(format!(
+        "unsaved-{}.txt",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_or(0, |d| d.as_nanos())
+    ));
+    let mut opts = std::fs::OpenOptions::new();
+    opts.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        opts.mode(0o600);
+    }
+    let mut file = opts
+        .open(&path)
+        .with_context(|| format!("failed to create {}", path.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        file.set_permissions(std::fs::Permissions::from_mode(0o600))
+            .context("failed to chmod unsaved-edit file")?;
+    }
+    file.write_all(buf.as_bytes())
+        .context("failed to write unsaved-edit file")?;
+    Ok(path)
+}
+
+fn err_with_unsaved(err: anyhow::Error, plaintext: &str) -> anyhow::Error {
+    match persist_unsaved_edit(plaintext) {
+        Ok(path) => err.context(format!(
+            "plaintext you just typed is in {} — delete that file after recovering",
+            path.display()
+        )),
+        Err(stash_err) => err.context(stash_err),
+    }
+}
+
+fn after_editor<T>(
+    source: rbw::edit::Source,
+    plaintext: &str,
+    result: anyhow::Result<T>,
+) -> anyhow::Result<T> {
+    result.map_err(|err| {
+        // Server write already landed. Do not stash, and do not tell
+        // a pipe caller to regenerate the value.
+        if is_local_cache_refresh_failed(&err) {
+            err
+        } else if persist_unsaved_after_edit(source) {
+            err_with_unsaved(err, plaintext)
+        } else {
+            err.context(
+                "the piped value was not written to disk; \
+                 re-run the producing command",
+            )
+        }
+    })
+}
+
+#[derive(Debug)]
+struct LocalCacheRefreshFailed;
+
+impl std::fmt::Display for LocalCacheRefreshFailed {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(
+            "saved on the server, but local cache refresh failed; \
+             run `rbw sync` and do not retry the write",
+        )
+    }
+}
+
+impl std::error::Error for LocalCacheRefreshFailed {}
+
+/// Persist local state after `add` / `edit_with_meta` already returned
+/// Ok. `new_token` is that Ok value's optional refreshed access token,
+/// so the call site has to have completed the server write first.
+/// Token save, vault sync, and db reload are exit 2 on failure.
+fn after_server_write(
+    db: &mut rbw::db::Db,
+    new_token: Option<String>,
+) -> anyhow::Result<()> {
+    if let Some(new_token) = new_token {
+        db.access_token = Some(new_token);
+        save_db(db).context(LocalCacheRefreshFailed)?;
+    }
+    crate::actions::sync().context(LocalCacheRefreshFailed)?;
+    *db = load_db().context(LocalCacheRefreshFailed)?;
+    Ok(())
+}
+
+fn is_local_cache_refresh_failed(err: &anyhow::Error) -> bool {
+    // anyhow::Error::is sees a `.context(LocalCacheRefreshFailed)`
+    // wrapper; `chain()` downcast does not, because the concrete
+    // type is anyhow's private context object.
+    err.is::<LocalCacheRefreshFailed>()
+}
+
+pub fn exit_status(err: &anyhow::Error) -> i32 {
+    if is_local_cache_refresh_failed(err) {
+        2
+    } else {
+        1
+    }
+}
+
+fn put_cipher(
+    db: &mut rbw::db::Db,
+    entry: &rbw::db::Entry,
+    data: &rbw::db::EntryData,
+    fields: &[rbw::db::Field],
+    notes: Option<&str>,
+    history: &[rbw::db::HistoryEntry],
+) -> anyhow::Result<()> {
+    let meta = entry.cipher_write_meta();
+    let access_token = db.access_token.as_ref().unwrap();
+    let refresh_token = db.refresh_token.as_ref().unwrap();
+    let (new_token, ()) = rbw::actions::edit_with_meta(
         access_token,
         refresh_token,
         &entry.id,
         entry.org_id.as_deref(),
         &entry.name,
-        &data,
-        &fields,
-        notes.as_deref(),
+        data,
+        fields,
+        notes,
         entry.folder_id.as_deref(),
-        &history,
-    )? {
-        db.access_token = Some(access_token);
-        save_db(&db)?;
-    }
-
-    crate::actions::sync()?;
-    Ok(())
+        history,
+        &meta,
+    )?;
+    // Agent rebuilds the master-password-reprompt ciphertext set only
+    // during sync, and only after the new vault is on disk. Any local
+    // failure after the PUT (token save, sync, reload) is exit 2: the
+    // server write landed; callers must not retry it.
+    after_server_write(db, new_token)
 }
 
 pub fn remove(
@@ -1944,8 +2124,19 @@ pub fn purge() -> anyhow::Result<()> {
     stop_agent()?;
 
     remove_db()?;
+    remove_unsaved_edits()?;
 
     Ok(())
+}
+
+fn remove_unsaved_edits() -> anyhow::Result<()> {
+    let dir = rbw::dirs::unsaved_edit_dir();
+    match std::fs::remove_dir_all(&dir) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e)
+            .with_context(|| format!("failed to remove {}", dir.display())),
+    }
 }
 
 pub fn stop_agent() -> anyhow::Result<()> {
@@ -2012,15 +2203,27 @@ fn version_or_quit() -> anyhow::Result<u32> {
 
 fn find_entry(
     db: &rbw::db::Db,
-    mut needle: Needle,
+    needle: Needle,
     username: Option<&str>,
     folder: Option<&str>,
     ignore_case: bool,
 ) -> anyhow::Result<(rbw::db::Entry, DecryptedCipher)> {
+    let entry = find_db_entry(db, needle, username, folder, ignore_case)?;
+    let decrypted_entry = decrypt_cipher(&entry)?;
+    Ok((entry, decrypted_entry))
+}
+
+fn find_db_entry(
+    db: &rbw::db::Db,
+    mut needle: Needle,
+    username: Option<&str>,
+    folder: Option<&str>,
+    ignore_case: bool,
+) -> anyhow::Result<rbw::db::Entry> {
     if let Needle::Uuid(uuid, s) = needle {
         for cipher in &db.entries {
             if uuid::Uuid::parse_str(&cipher.id) == Ok(uuid) {
-                return Ok((cipher.clone(), decrypt_cipher(cipher)?));
+                return Ok(cipher.clone());
             }
         }
         needle = Needle::Name(s);
@@ -2036,8 +2239,7 @@ fn find_entry(
         .collect::<anyhow::Result<_>>()?;
     let (entry, _) =
         find_entry_raw(&ciphers, &needle, username, folder, ignore_case)?;
-    let decrypted_entry = decrypt_cipher(&entry)?;
-    Ok((entry, decrypted_entry))
+    Ok(entry)
 }
 
 fn find_entry_raw(
@@ -4157,6 +4359,9 @@ mod test {
                 history: vec![],
                 key: None,
                 master_password_reprompt: rbw::api::CipherRepromptType::None,
+                favorite: false,
+                archived_date: None,
+                revision_date: None,
             },
             DecryptedSearchCipher {
                 id: id.to_string(),
@@ -4174,5 +4379,75 @@ mod test {
                 notes: None,
             },
         )
+    }
+
+    #[test]
+    fn test_persist_unsaved_after_edit_skips_pipe() {
+        assert!(!persist_unsaved_after_edit(rbw::edit::Source::Pipe));
+        assert!(persist_unsaved_after_edit(rbw::edit::Source::Editor));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_persist_unsaved_edit_permissions() {
+        use std::os::unix::fs::PermissionsExt as _;
+        let dir = tempfile::tempdir().unwrap();
+        let path =
+            persist_unsaved_edit_in(dir.path(), "secret-value").unwrap();
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "secret-value");
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+        assert_eq!(
+            std::fs::metadata(dir.path()).unwrap().permissions().mode()
+                & 0o777,
+            0o700
+        );
+    }
+
+    #[test]
+    fn test_after_editor_pipe_does_not_mention_stash() {
+        let err = after_editor::<()>(
+            rbw::edit::Source::Pipe,
+            "piped-secret",
+            Err(anyhow::anyhow!("put failed")),
+        )
+        .unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("put failed"));
+        assert!(msg.contains("the piped value was not written to disk"));
+        assert!(!msg.contains("plaintext you just typed"));
+    }
+
+    #[test]
+    fn test_after_editor_does_not_stash_after_server_save() {
+        let err = anyhow::anyhow!("network").context(LocalCacheRefreshFailed);
+        let err = after_editor::<()>(
+            rbw::edit::Source::Editor,
+            "typed-secret",
+            Err(err),
+        )
+        .unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("do not retry the write"));
+        assert!(!msg.contains("plaintext you just typed"));
+        assert_eq!(exit_status(&err), 2);
+        assert_eq!(exit_status(&anyhow::anyhow!("put failed")), 1);
+    }
+
+    #[test]
+    fn test_after_editor_pipe_does_not_rerun_after_server_save() {
+        let err = anyhow::anyhow!("network").context(LocalCacheRefreshFailed);
+        let err = after_editor::<()>(
+            rbw::edit::Source::Pipe,
+            "piped-secret",
+            Err(err),
+        )
+        .unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("do not retry the write"));
+        assert!(!msg.contains("the piped value was not written to disk"));
+        assert_eq!(exit_status(&err), 2);
     }
 }

--- a/src/bin/rbw/main.rs
+++ b/src/bin/rbw/main.rs
@@ -1,6 +1,5 @@
 use std::io::Write as _;
 
-use anyhow::Context as _;
 use clap::{CommandFactory as _, Parser as _};
 
 mod actions;
@@ -226,7 +225,8 @@ enum Opt {
     #[command(about = "Lock the password database")]
     Lock,
 
-    #[command(about = "Remove the local copy of the password database")]
+    #[command(about = "Remove the local copy of the password database, \
+            including unsaved editor buffers")]
     Purge,
 
     #[command(name = "stop-agent", about = "Terminate the background agent")]
@@ -515,11 +515,11 @@ fn main() {
             }
             Ok(())
         }
-    }
-    .with_context(|| format!("rbw {subcommand_name}"));
+    };
 
     if let Err(e) = res {
-        eprintln!("{e:#}");
-        std::process::exit(1);
+        let code = commands::exit_status(&e);
+        eprintln!("{:#}", e.context(format!("rbw {subcommand_name}")));
+        std::process::exit(code);
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -19,11 +19,52 @@ pub struct Entry {
     pub history: Vec<HistoryEntry>,
     pub key: Option<String>,
     pub master_password_reprompt: crate::api::CipherRepromptType,
+    // Official Bitwarden PUT maps omitted bool/enum/date fields to
+    // defaults (favorite=false, reprompt=None, archivedDate=null) via
+    // CipherRequestModel.ToCipherDetails(existingCipher). Persist what
+    // sync gave us so a field-only edit does not clobber them.
+    //
+    // `serde(default)` is only for reading a 1.15.0 on-disk cache.
+    // Those defaults are not server truth — `edit` syncs before
+    // resolving the selector so the first PUT after upgrade does not
+    // unfavorite/unarchive.
+    //
+    // Adding these fields is a Rust source break for downstream struct
+    // literals. JSON load stays compatible. Cipher PUTs go through
+    // `edit_with_meta`; the 1.15 `edit` signatures are gone because
+    // they omitted `key` and reset favorite/archive.
+    #[serde(default)]
+    pub favorite: bool,
+    #[serde(default)]
+    pub archived_date: Option<String>,
+    #[serde(default)]
+    pub revision_date: Option<String>,
+}
+
+/// PUT metadata copied from a post-sync `Entry`. Prefer this over
+/// scattering more positional arguments; tests can lock the mapping.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CipherWriteMeta<'a> {
+    pub key: Option<&'a str>,
+    pub reprompt: crate::api::CipherRepromptType,
+    pub favorite: bool,
+    pub archived_date: Option<&'a str>,
+    pub last_known_revision_date: Option<&'a str>,
 }
 
 impl Entry {
     pub fn master_password_reprompt(&self) -> bool {
         self.master_password_reprompt != crate::api::CipherRepromptType::None
+    }
+
+    pub fn cipher_write_meta(&self) -> CipherWriteMeta<'_> {
+        CipherWriteMeta {
+            key: self.key.as_deref(),
+            reprompt: self.master_password_reprompt,
+            favorite: self.favorite,
+            archived_date: self.archived_date.as_deref(),
+            last_known_revision_date: self.revision_date.as_deref(),
+        }
     }
 }
 
@@ -312,5 +353,57 @@ impl Db {
             || self.iterations.is_none()
             || self.kdf.is_none()
             || self.protected_key.is_none()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_entry() -> Entry {
+        Entry {
+            id: "id".into(),
+            org_id: None,
+            folder: None,
+            folder_id: None,
+            name: "enc".into(),
+            data: EntryData::SecureNote,
+            fields: vec![],
+            notes: None,
+            history: vec![],
+            key: Some("item-key".into()),
+            master_password_reprompt:
+                crate::api::CipherRepromptType::Password,
+            favorite: true,
+            archived_date: Some("2026-01-01T00:00:00Z".into()),
+            revision_date: Some("2026-02-01T00:00:00Z".into()),
+        }
+    }
+
+    #[test]
+    fn cipher_write_meta_uses_entry_values_not_defaults() {
+        let entry = sample_entry();
+        let meta = entry.cipher_write_meta();
+        assert_eq!(meta.key, Some("item-key"));
+        assert_eq!(meta.reprompt, crate::api::CipherRepromptType::Password);
+        assert!(meta.favorite);
+        assert_eq!(meta.archived_date, Some("2026-01-01T00:00:00Z"));
+        assert_eq!(
+            meta.last_known_revision_date,
+            Some("2026-02-01T00:00:00Z")
+        );
+    }
+
+    #[test]
+    fn old_cache_json_defaults_are_not_server_truth() {
+        let mut value = serde_json::to_value(sample_entry()).unwrap();
+        let obj = value.as_object_mut().unwrap();
+        obj.remove("favorite");
+        obj.remove("archived_date");
+        obj.remove("revision_date");
+        let entry: Entry = serde_json::from_value(value).unwrap();
+        assert!(!entry.favorite);
+        assert!(entry.archived_date.is_none());
+        assert!(entry.revision_date.is_none());
     }
 }

--- a/src/dirs.rs
+++ b/src/dirs.rs
@@ -10,7 +10,7 @@ pub fn make_all() -> Result<()> {
     Ok(())
 }
 
-fn create_dir_all_with_permissions(
+pub fn create_dir_all_with_permissions(
     path: &std::path::Path,
     mode: u32,
 ) -> Result<()> {
@@ -69,6 +69,12 @@ pub fn socket_file() -> std::path::PathBuf {
 
 pub fn ssh_agent_socket_file() -> std::path::PathBuf {
     runtime_dir().join("ssh-agent-socket")
+}
+
+/// Directory for editor buffers kept after a failed cipher PUT.
+/// Under the rbw runtime dir (not a shared world-readable $TMPDIR).
+pub fn unsaved_edit_dir() -> std::path::PathBuf {
+    runtime_dir().join("unsaved-edits")
 }
 
 fn config_dir() -> std::path::PathBuf {

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -4,12 +4,31 @@ use std::io::{Read as _, Write as _};
 
 use is_terminal::IsTerminal as _;
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Source {
+    Pipe,
+    Editor,
+}
+
+pub fn stdin_is_pipe() -> bool {
+    !std::io::stdin().is_terminal()
+}
+
+/// Read an edited buffer from a pipe or `$VISUAL`/`$EDITOR`.
+///
+/// Drops whether the value came from a pipe. Prefer [`edit_from`] when
+/// the caller must treat those sources differently (for example to
+/// avoid writing piped secrets to disk).
 pub fn edit(contents: &str, help: &str) -> Result<String> {
-    if !std::io::stdin().is_terminal() {
+    Ok(edit_from(contents, help)?.0)
+}
+
+pub fn edit_from(contents: &str, help: &str) -> Result<(String, Source)> {
+    if stdin_is_pipe() {
         // directly read from piped content
         return match std::io::read_to_string(std::io::stdin()) {
             Err(e) => Err(Error::FailedToReadFromStdin { err: e }),
-            Ok(res) => Ok(res),
+            Ok(res) => Ok((res, Source::Pipe)),
         };
     }
 
@@ -87,7 +106,7 @@ pub fn edit(contents: &str, help: &str) -> Result<String> {
     fh.read_to_string(&mut contents).unwrap();
     drop(fh);
 
-    Ok(contents)
+    Ok((contents, Source::Editor))
 }
 
 fn contains_shell_metacharacters(cmd: &std::ffi::OsStr) -> bool {

--- a/src/error.rs
+++ b/src/error.rs
@@ -75,6 +75,12 @@ pub enum Error {
     InvalidCipherString { reason: String },
 
     #[error(
+        "cipher was changed on the server since this snapshot; \
+         run rbw sync and retry"
+    )]
+    CipherRevisionConflict,
+
+    #[error(
         "invalid value for ${var}: {}",
         .editor.to_string_lossy()
     )]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,5 +1,18 @@
 use std::os::unix::ffi::{OsStrExt as _, OsStringExt as _};
 
+/// Increment when the client/agent JSON protocol changes, even if the
+/// crate version does not.
+///
+/// serde ignores unknown `Action` fields. A leftover 1.15.0 agent would
+/// therefore accept `Encrypt` without `entry_key`, encrypt with the
+/// user/org key, and the new CLI would PUT that ciphertext while still
+/// sending the item `key` — mixed-key corruption. `ensure_agent()`
+/// compares [`VERSION`] and restarts the agent on mismatch, so this
+/// revision is the fail-closed gate. Do not rely on bumping Cargo.toml
+/// alone: the crate-version term below collides for some triples
+/// (1.15.1 and 1.16.0 both add to `17_000_000`).
+pub const PROTOCOL_REVISION: u32 = 1;
+
 pub const VERSION: u32 = {
     const fn unwrap(res: &Result<u32, std::num::ParseIntError>) -> u32 {
         match res {
@@ -15,6 +28,7 @@ pub const VERSION: u32 = {
     unwrap(&u32::from_str_radix(major, 10)) * 1_000_000
         + unwrap(&u32::from_str_radix(minor, 10)) * 1_000_000
         + unwrap(&u32::from_str_radix(patch, 10)) * 1_000_000
+        + PROTOCOL_REVISION
 };
 
 #[derive(serde::Serialize, serde::Deserialize, Debug)]
@@ -181,6 +195,9 @@ pub enum Action {
     },
     Encrypt {
         plaintext: String,
+        // Bump PROTOCOL_REVISION when this shape changes. Unknown fields
+        // are ignored, so an old agent would encrypt without this key.
+        entry_key: Option<String>,
         org_id: Option<String>,
     },
     ClipboardStore {
@@ -198,4 +215,53 @@ pub enum Response {
     Decrypt { plaintext: String },
     Encrypt { cipherstring: String },
     Version { version: u32 },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn version_includes_protocol_revision() {
+        assert_eq!(VERSION % 1_000_000, PROTOCOL_REVISION);
+    }
+
+    #[test]
+    fn encrypt_action_accepts_legacy_json_without_entry_key() {
+        let action: Action = serde_json::from_str(
+            r#"{"type":"Encrypt","plaintext":"p","org_id":null}"#,
+        )
+        .unwrap();
+        match action {
+            Action::Encrypt {
+                plaintext,
+                entry_key,
+                org_id,
+            } => {
+                assert_eq!(plaintext, "p");
+                assert!(entry_key.is_none());
+                assert!(org_id.is_none());
+            }
+            _ => panic!("expected Encrypt"),
+        }
+    }
+
+    #[test]
+    fn encrypt_action_roundtrips_entry_key() {
+        let action = Action::Encrypt {
+            plaintext: "p".into(),
+            entry_key: Some("k".into()),
+            org_id: None,
+        };
+        let json = serde_json::to_string(&action).unwrap();
+        assert!(json.contains("entry_key"));
+        let back: Action = serde_json::from_str(&json).unwrap();
+        match back {
+            Action::Encrypt {
+                entry_key: Some(key),
+                ..
+            } => assert_eq!(key, "k"),
+            other => panic!("expected Encrypt with key, got {other:?}"),
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Encrypt edited values with an entry's individual item key and send the key plus `reprompt`, `favorite`, `archivedDate`, and `lastKnownRevisionDate` on full cipher PUTs.
- Sync before selector resolution and after successful writes; update the agent's reprompt set only after the vault is persisted, and report post-write local failures with exit 2 so callers do not retry a write that landed.
- Preserve failed interactive editor buffers with restrictive permissions while keeping piped secrets off disk. This removes the unsafe `actions::edit` / `Client::edit` library entry points in favor of `edit_with_meta` and adds fields to `db::Entry`, which is a documented Rust source break.

## Relationship to #368

This overlaps #368 by @Mic92, which was opened first and fixes the same item-key corruption more narrowly. The item-key approach here is the same one; this PR additionally preserves `reprompt` / `favorite` / `archivedDate`, sends `lastKnownRevisionDate` so a stale full PUT cannot clobber a concurrent edit, fixes the agent's reprompt-set ordering, and reworks post-write exit semantics. Those additions are why it renames `edit` to `edit_with_meta` instead of adding a `key` parameter, so the two branches conflict textually.

Either order works. If #368 merges first I will rebase onto it and drop the duplicated part; if this one is preferred, #368 can be closed.

## Test plan
- [x] `cargo test --all-features`
- [x] `cargo clippy --bin rbw --lib -- -D warnings`
- [x] `cargo fmt --check`
- [ ] Edit a keyed item against a real vault and verify it remains decryptable
- [ ] Trigger a stale cipher write and verify it does not overwrite a concurrent edit
- [ ] Verify post-write sync failure exits 2 without suggesting a retry

CI's `lint` job is red here for reasons that predate this branch: stable clippy 1.98 fails `--all-targets --all-features -- -Dwarnings` on `main` itself, at eight sites in code this PR does not touch. #373 fixes those. That job then fails again at `cargo deny check` on RustSec advisories in `Cargo.lock` (`bytes`, `quick-xml`, `rand`, `rustls-webpki`, yanked `spin`), which is also independent of this branch and needs a dependency refresh. `cargo clippy --bin rbw --lib`, `cargo fmt --check`, and `cargo test --all-features` are clean on this branch.

Related: #364


