### PR TITLE
Fix clippy 1.98 lints

### DIFF
--- a/src/actions.rs
+++ b/src/actions.rs
@@ -112,21 +112,17 @@ pub fn unlock<S: std::hash::BuildHasher>(
 
     let protected_private_key =
         crate::cipherstring::CipherString::new(protected_private_key)?;
-    let private_key =
-        match protected_private_key.decrypt_locked_symmetric(&key) {
-            Ok(private_key) => crate::locked::PrivateKey::new(private_key),
-            Err(e) => return Err(e),
-        };
+    let private_key = crate::locked::PrivateKey::new(
+        protected_private_key.decrypt_locked_symmetric(&key)?,
+    );
 
     let mut org_keys = std::collections::HashMap::new();
     for (org_id, protected_org_key) in protected_org_keys {
         let protected_org_key =
             crate::cipherstring::CipherString::new(protected_org_key)?;
-        let org_key =
-            match protected_org_key.decrypt_locked_asymmetric(&private_key) {
-                Ok(org_key) => crate::locked::Keys::new(org_key),
-                Err(e) => return Err(e),
-            };
+        let org_key = crate::locked::Keys::new(
+            protected_org_key.decrypt_locked_asymmetric(&private_key)?,
+        );
         org_keys.insert(org_id.clone(), org_key);
     }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -1738,23 +1738,19 @@ fn classify_login_error(error_res: &ConnectErrorRes, code: u16) -> Error {
         "invalid_client" => {
             return Error::IncorrectApiKey;
         }
-        "" => {
-            // bitwarden_rs returns an empty error and error_description for
-            // this case, for some reason
-            if error_desc.is_none() || error_desc == Some("") {
-                if let Some(error_model) = error_res.error_model.as_ref() {
-                    let message = error_model.message.as_str().to_string();
-                    match message.as_str() {
-                        "Username or password is incorrect. Try again"
-                        | "TOTP code is not a number" => {
+        // bitwarden_rs returns an empty error and error_description for
+        // this case, for some reason
+        "" if error_desc.is_none() || error_desc == Some("") => {
+            if let Some(error_model) = error_res.error_model.as_ref() {
+                let message = error_model.message.as_str().to_string();
+                match message.as_str() {
+                    "Username or password is incorrect. Try again"
+                    | "TOTP code is not a number" => {
+                        return Error::IncorrectPassword { message };
+                    }
+                    s => {
+                        if s.starts_with("Invalid TOTP code! Server time: ") {
                             return Error::IncorrectPassword { message };
-                        }
-                        s => {
-                            if s.starts_with(
-                                "Invalid TOTP code! Server time: ",
-                            ) {
-                                return Error::IncorrectPassword { message };
-                            }
                         }
                     }
                 }

--- a/src/bin/rbw-agent/debugger.rs
+++ b/src/bin/rbw-agent/debugger.rs
@@ -27,7 +27,7 @@ pub fn disable_tracing() -> anyhow::Result<()> {
     if ret != 0 {
         let e = std::io::Error::last_os_error();
         return Err(anyhow::anyhow!(
-            "failed to deny debugger attach, agent memory may be readable by other processes: {}", e
+            "failed to deny debugger attach, agent memory may be readable by other processes: {e}"
         ));
     }
 
@@ -38,11 +38,11 @@ pub fn disable_tracing() -> anyhow::Result<()> {
     };
     // safety: correct argument
     // https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/setrlimit.2.html
-    let ret = unsafe { libc::setrlimit(libc::RLIMIT_CORE, &rlim) };
+    let ret = unsafe { libc::setrlimit(libc::RLIMIT_CORE, &raw const rlim) };
     if ret != 0 {
         let e = std::io::Error::last_os_error();
         return Err(anyhow::anyhow!(
-            "failed to disable core dumps, agent memory may be dumped to disk: {}", e
+            "failed to disable core dumps, agent memory may be dumped to disk: {e}"
         ));
     }
 

--- a/src/bin/rbw/commands.rs
+++ b/src/bin/rbw/commands.rs
@@ -1507,8 +1507,7 @@ pub fn search(
         .filter(|entry| {
             entry
                 .as_ref()
-                .map(|entry| entry.search_match(term, folder))
-                .unwrap_or(true)
+                .map_or(true, |entry| entry.search_match(term, folder))
         })
         .map(|entry| entry.map(std::convert::Into::into))
         .collect::<Result<_, anyhow::Error>>()?;

--- a/src/dirs.rs
+++ b/src/dirs.rs
@@ -97,7 +97,7 @@ fn runtime_dir() -> std::path::PathBuf {
             format!(
                 "{}/{}-{}",
                 std::env::temp_dir().to_string_lossy(),
-                &profile(),
+                profile(),
                 rustix::process::getuid().as_raw()
             )
             .into()


### PR DESCRIPTION
## Summary
- `cargo clippy --all-targets --all-features -- -Dwarnings` (the CI lint job) currently fails on `main` with stable clippy 1.98. CI reports four of them; the other four are hidden because the library fails to compile first.
- Fixes all eight with no behavior change: `question_mark` in `actions::unlock` (x2), `collapsible_match` in `api::classify_login_error`, `useless_borrows_in_formatting` in `dirs::runtime_dir`, `map_unwrap_or` in `commands::search`, and `uninlined_format_args` (x2) plus `borrow_as_ptr` in `rbw-agent::debugger`.

The `collapsible_match` fix turns the `""` arm of `classify_login_error` into a guarded arm. Behavior is unchanged: when the guard is false the value falls through to the existing `_ => {}`, which is what the inner `if` already did.

MSRV stays at 1.82: `&raw const` is stable in 1.82 and `Result::is_ok_and` in 1.70.

## CI note

With this branch the `lint` job now gets past `cargo clippy` and `cargo fmt --check` for the first time, and then fails at its third step, `cargo deny check`, on RustSec advisories in `Cargo.lock` (`bytes` integer overflow, two `quick-xml` DoS advisories, `rand` unsoundness, four `rustls-webpki` advisories, and yanked `spin`). Those are independent of this change and need a dependency refresh, which seemed like your call rather than something to fold in here.

## Test plan
- [x] `cargo clippy --all-targets --all-features -- -Dwarnings` (clean; was 8 errors)
- [x] `cargo fmt --check`
- [x] `cargo test --all-features`
- [x] Verified against stable 1.98.0, the same version CI resolves

